### PR TITLE
don't rate limit key when registering handlers

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -217,7 +217,7 @@ func (c *controller) EnqueueKey(key string) {
 	if c.workqueue == nil {
 		c.startKeys = append(c.startKeys, startKey{key: key})
 	} else {
-		c.workqueue.AddRateLimited(key)
+		c.workqueue.Add(key)
 	}
 }
 


### PR DESCRIPTION
Problem:
EnqueueKey rate limits the key and is called by sharedcontroller's RegisterHandler.
This is an issue because on startup we start enqueuing each key for each handler, causing the rate limit duration spike to hours very quickly.

Solution:
Adding the key to workqueue directly in EnqueueKey. Also what we used to do it 2.4.x,
https://github.com/rancher/norman/blob/release/v2.4/controller/generic_controller.go#L187