### PR TITLE
Add a max timeout bucket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/rancher/lasso
 go 1.14
 
 require (
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.8
+	k8s.io/klog v1.0.0
 )

--- a/pkg/workqueue/workqueue.go
+++ b/pkg/workqueue/workqueue.go
@@ -1,0 +1,36 @@
+package workqueue
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func NewBucketRateLimiterWithMaxTimeout(qps, burst int, max time.Duration) *BucketRateLimiterWithMaxTimeout {
+	return &BucketRateLimiterWithMaxTimeout{
+		Limiter:    rate.NewLimiter(rate.Limit(qps), burst),
+		MaxTimeout: max,
+	}
+}
+
+// BucketRateLimiterWithMaxTimeout adapts a standard bucket to the workqueue ratelimiter API
+// with a max timeout since a bucket is limitless by default
+type BucketRateLimiterWithMaxTimeout struct {
+	*rate.Limiter
+	MaxTimeout time.Duration
+}
+
+func (r *BucketRateLimiterWithMaxTimeout) When(item interface{}) time.Duration {
+	timeout := r.Limiter.Reserve().Delay()
+	if timeout > r.MaxTimeout {
+		return r.MaxTimeout
+	}
+	return timeout
+}
+
+func (r *BucketRateLimiterWithMaxTimeout) NumRequeues(item interface{}) int {
+	return 0
+}
+
+func (r *BucketRateLimiterWithMaxTimeout) Forget(item interface{}) {
+}


### PR DESCRIPTION
Problem:
The bucket being used `rate.Limiter` does not have a maximum timeout so on startup if we process thousands of objects for the same item type this bucket can end up at hours long wait times. It then takes that same amount of time for the bucket to go back to zero. 

Solution:
Wrap the `rate.Limiter` with a max timeout of 2 min 