### PR TITLE
Updated to use v1 API for CustomResourceDefinition

### DIFF
--- a/pkg/dynamic/gvks.go
+++ b/pkg/dynamic/gvks.go
@@ -34,7 +34,7 @@ func watchGVKS(ctx context.Context,
 
 	crdController, err := factory.ForKind(schema.GroupVersionKind{
 		Group:   "apiextensions.k8s.io",
-		Version: "v1beta1",
+		Version: "v1",
 		Kind:    "CustomResourceDefinition",
 	})
 	if err != nil {


### PR DESCRIPTION
Replaced CRD API from `v1beta1` to `v1` to support k8s v1.22.
Note that apiextensions.k8s.io/v1 for CRD is supported from k8s v1.16 making it OK to do straight change as Rancher v2.6 release to support k8s 1.18+.