### PR TITLE
[2.5] fix gouroutine leak when sharedcontroller has been started

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -133,6 +133,9 @@ func (c *controller) run(workers int, stopCh <-chan struct{}) {
 	}
 
 	<-stopCh
+	c.startLock.Lock()
+	defer c.startLock.Unlock()
+	c.started = false
 	log.Infof("Shutting down %s workers", c.name)
 }
 

--- a/pkg/controller/sharedcontroller.go
+++ b/pkg/controller/sharedcontroller.go
@@ -89,6 +89,10 @@ func (s *sharedController) Start(ctx context.Context, workers int) error {
 		return s.startError
 	}
 
+	if s.started {
+		return nil
+	}
+
 	if err := s.controller.Start(ctx, workers); err != nil {
 		return err
 	}


### PR DESCRIPTION
1. Rancher will start a usermanager controller for each downstream cluster, and will start management controller factory [here](https://github.com/rancher/rancher/blob/08ad9f793a2345478a26a514fca021c8e648f2f3/pkg/types/config/context.go#L476). The management controller factory will start only once cause it checked `started` state [here](https://github.com/rancher/lasso/blob/release/v2.5.8-patch1/pkg/controller/controller.go#L143). If there's something wrong with downstream cluster and usermanager controller has to stop, it canceled the context and skip goroutine [here](https://github.com/rancher/lasso/blob/release/v2.5.8-patch1/pkg/controller/sharedcontroller.go#L101). The management controller factory is never canceled, so that each time we start a usermanager controller, the goroutine leaks [here](https://github.com/rancher/lasso/blob/release/v2.5.8-patch1/pkg/controller/sharedcontroller.go#L97). So we also need to check `started` state to avoid create more goroutine leaks if controller has started.

2. It set `started` state in Start() function but never set `unstarted` state for shutting down works when channel done. The controller may fail to start when we restart it.