### PR TITLE
[2.5] fix gouroutine leak when sharedcontroller has been started

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -143,6 +143,9 @@ func (c *controller) run(workers int, stopCh <-chan struct{}) {
 	}
 
 	<-stopCh
+	c.startLock.Lock()
+	defer c.startLock.Unlock()
+	c.started = false
 	log.Infof("Shutting down %s workers", c.name)
 }
 

--- a/pkg/controller/sharedcontroller.go
+++ b/pkg/controller/sharedcontroller.go
@@ -89,6 +89,10 @@ func (s *sharedController) Start(ctx context.Context, workers int) error {
 		return s.startError
 	}
 
+	if s.started {
+		return nil
+	}
+
 	if err := s.controller.Start(ctx, workers); err != nil {
 		return err
 	}


### PR DESCRIPTION
Missing fix for https://github.com/rancher/lasso/pull/11