### PR TITLE
Don't cancel timeout context after failure and first loop

### DIFF
--- a/pkg/dynamic/controller.go
+++ b/pkg/dynamic/controller.go
@@ -214,11 +214,9 @@ outer:
 		if !cache.WaitForCacheSync(timeoutCtx.Done(), w.informer.HasSynced) {
 			errs = append(errs, fmt.Errorf("failed to sync cache for %v", w.gvk))
 			log.Errorf("failed to sync cache for %v", w.gvk)
-			cancel()
 			w.cancel()
 			delete(c.watchers, w.gvk)
 		}
-		cancel()
 	}
 
 	for _, w := range toWait {


### PR DESCRIPTION
By canceling the timeoutCtx here it has the side effect that any
cache later in the toWait list will be canceled if it hasn't finished
yet.  The side effect of this is that we only really wait for the
first cache and then if any other cache isn't don't we cancel them.

This is the source of errors like

failed to sync schemas: failed to sync cache for /v1, Kind=Secret

You may see these errors in the Rancher cluster agent when Steve is
starting, but you will definitely see these errors when running wtfk8s.

Signed-off-by: Darren Shepherd <darren@acorn.io>
