### PR TITLE
Explain default rate limiting behavior

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -102,7 +102,7 @@ func applyDefaultOptions(opts *Options) *Options {
 		newOpts = *opts
 	}
 
-	// from failure 1 to 12: exponential growth in delays (5 ms * 2 ^ failures)
+	// from failure 0 to 12: exponential growth in delays (5 ms * 2 ^ failures)
 	// from failure 13 to 30: 30s delay
 	// from failure 31 on: 120s delay (2 minutes)
 	if newOpts.RateLimiter == nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -101,6 +101,10 @@ func applyDefaultOptions(opts *Options) *Options {
 	if opts != nil {
 		newOpts = *opts
 	}
+
+	// from failure 1 to 12: exponential growth in delays (5 ms * 2 ^ failures)
+	// from failure 13 to 30: 30s delay
+	// from failure 31 on: 120s delay (2 minutes)
 	if newOpts.RateLimiter == nil {
 		newOpts.RateLimiter = workqueue.NewMaxOfRateLimiter(
 			workqueue.NewItemFastSlowRateLimiter(time.Millisecond, maxTimeout2min, 30),


### PR DESCRIPTION
I found it a bit tricky to understand how default work queue rate limiting works, and thought that it could be beneficial to recap the expected behavior for the next ones looking into it.

Graph:

![image](https://github.com/rancher/lasso/assets/250541/415f0437-165b-4906-b47b-9b25b1953ea6)

X axis: number of failures
Y axis: time to wait in milliseconds