### PR TITLE
Troubleshooting memory usage for caches

### DIFF
--- a/pkg/cache/metrics.go
+++ b/pkg/cache/metrics.go
@@ -1,0 +1,80 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rancher/lasso/pkg/metrics"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	cacheMetricsCollectionPeriod = 1 * time.Minute
+	cacheContextLabel            = "context"
+	cacheKindLabel               = "kind"
+)
+
+var (
+	cacheStoreCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: "cache",
+			Name:      "store_count",
+			Help:      "Number of items in the cache store",
+		}, []string{cacheContextLabel, cacheKindLabel},
+	)
+	cacheStartedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: "cache",
+			Name:      "started_count",
+			Help:      "Number of started caches per factory",
+		}, []string{cacheContextLabel},
+	)
+)
+
+func init() {
+	metrics.Register(cacheStoreCount, cacheStartedCount)
+}
+
+func startMetricsCollection(ctx context.Context, s *sharedCacheFactory, contextName string) {
+	go func() {
+		ticker := time.NewTicker(cacheMetricsCollectionPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			factoryMetrics := collectMetrics(s)
+			for kind, count := range factoryMetrics.numEntries {
+				cacheStoreCount.WithLabelValues(contextName, kind).Set(float64(count))
+			}
+			cacheStartedCount.WithLabelValues(contextName).Set(float64(factoryMetrics.startedCaches))
+			ticker.Reset(cacheMetricsCollectionPeriod)
+		}
+	}()
+}
+
+func collectMetrics(s *sharedCacheFactory) sharedCacheFactoryMetrics {
+	numEntries := map[string]int{}
+	for gvk, c := range s.caches {
+		kindKey := objectKindKey(gvk)
+		items := c.GetStore().List()
+		numEntries[kindKey] = len(items)
+	}
+	return sharedCacheFactoryMetrics{
+		numEntries:    numEntries,
+		startedCaches: len(s.startedCaches),
+	}
+}
+
+type sharedCacheFactoryMetrics struct {
+	numEntries    map[string]int
+	startedCaches int
+}
+
+func objectKindKey(gvk schema.GroupVersionKind) string {
+	return gvk.Kind + "." + gvk.Group + "/" + gvk.Version
+}

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -29,3 +29,9 @@ func init() {
 		workqueue.SetProvider(workqueueMetricsProvider{})
 	}
 }
+
+func Register(cs ...prometheus.Collector) {
+	if prometheusMetrics {
+		prometheus.DefaultRegisterer.MustRegister(cs...)
+	}
+}


### PR DESCRIPTION
This PR includes some changes to ease troubleshooting memory issues in `rancher/rancher`.

1. By making the heap profile to split cache Reflector `List()` call into 3 different flames, depending on the context/client that uses it, for management context, user context in the local cluster (which may be a subset of the objects in the management context cache) and downstream contexts (aggregated).
2. Adds Prometheus metrics to count the number of started informers in each cache, as well as the number of items stored, by kind and context (identifying each of them by upstream vs. downstream, source and cluster name, if available).

Examples:
```
# HELP cache_started_count Number of started caches per factory
# TYPE cache_started_count gauge
cache_started_count{context="mgmt_context_authserver"} 8
cache_started_count{context="mgmt_context_core-at-ListenAndServe"} 1
cache_started_count{context="mgmt_context_multicluster_manager"} 60
cache_started_count{context="user_context_multicluster_manager_local"} 12
```

```
# HELP cache_store_count Number of items in the cache store
# TYPE cache_store_count gauge
...
cache_store_count{context="user_context_multicluster_manager_c-m-jwkvxjkf",kind="Secret./v1"} 22
cache_store_count{context="user_context_multicluster_manager_c-m-jwkvxjkf",kind="ServiceAccount./v1"} 51
cache_store_count{context="user_context_multicluster_manager_local",kind="APIService.apiregistration.k8s.io/v1"} 43
cache_store_count{context="user_context_multicluster_manager_local",kind="ClusterRole.rbac.authorization.k8s.io/v1"} 141
...
```