### PR TITLE
Adding support for transform functions

### DIFF
--- a/pkg/cache/sql/informer/informer_test.go
+++ b/pkg/cache/sql/informer/informer_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/rancher/lasso/pkg/cache/sql/partition"
@@ -61,7 +62,7 @@ func TestNewInformer(t *testing.T) {
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 
-		informer, err := NewInformer(dynamicClient, fields, gvk, dbClient, false, true)
+		informer, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.Nil(t, err)
 		assert.NotNil(t, informer.ByOptionsLister)
 		assert.NotNil(t, informer.SharedIndexInformer)
@@ -80,7 +81,7 @@ func TestNewInformer(t *testing.T) {
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(fmt.Errorf("error"))
 
-		_, err := NewInformer(dynamicClient, fields, gvk, dbClient, false, true)
+		_, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewIndexer(), should return an error", test: func(t *testing.T) {
@@ -105,7 +106,7 @@ func TestNewInformer(t *testing.T) {
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(fmt.Errorf("error"))
 
-		_, err := NewInformer(dynamicClient, fields, gvk, dbClient, false, true)
+		_, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.NotNil(t, err)
 	}})
 	tests = append(tests, testCase{description: "NewInformer() with errors returned from NewListOptionIndexer(), should return an error", test: func(t *testing.T) {
@@ -140,9 +141,93 @@ func TestNewInformer(t *testing.T) {
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(fmt.Errorf("error"))
 
-		_, err := NewInformer(dynamicClient, fields, gvk, dbClient, false, true)
+		_, err := NewInformer(dynamicClient, fields, nil, gvk, dbClient, false, true)
 		assert.NotNil(t, err)
 	}})
+	tests = append(tests, testCase{description: "NewInformer() with transform func", test: func(t *testing.T) {
+		dbClient := NewMockDBClient(gomock.NewController(t))
+		txClient := NewMockTXClient(gomock.NewController(t))
+		dynamicClient := NewMockResourceInterface(gomock.NewController(t))
+		mockInformer := mockInformer{}
+		testNewInformer := func(lw cache.ListerWatcher,
+			exampleObject runtime.Object,
+			defaultEventHandlerResyncPeriod time.Duration,
+			indexers cache.Indexers) cache.SharedIndexInformer {
+			return &mockInformer
+		}
+		newInformer = testNewInformer
+
+		fields := [][]string{{"something"}}
+		gvk := schema.GroupVersionKind{}
+
+		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
+		// is tested in depth in its own package.
+		dbClient.EXPECT().Begin().Return(txClient, nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Commit().Return(nil)
+		dbClient.EXPECT().Prepare(gomock.Any()).Return(&sql.Stmt{}).AnyTimes()
+
+		// NewIndexer() logic (within NewListOptionIndexer(). This test is only concerned with whether it returns err or not as NewIndexer
+		// is tested in depth in its own indexer_test.go
+		dbClient.EXPECT().Begin().Return(txClient, nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Commit().Return(nil)
+
+		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
+		// is tested in depth in its own indexer_test.go
+		dbClient.EXPECT().Begin().Return(txClient, nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
+		txClient.EXPECT().Commit().Return(nil)
+
+		transformFunc := func(input interface{}) (interface{}, error) {
+			return "someoutput", nil
+		}
+		informer, err := NewInformer(dynamicClient, fields, transformFunc, gvk, dbClient, false, true)
+		assert.Nil(t, err)
+		assert.NotNil(t, informer.ByOptionsLister)
+		assert.NotNil(t, informer.SharedIndexInformer)
+		assert.NotNil(t, mockInformer.transformFunc)
+
+		// we can't test func == func, so instead we check if the output was as expected
+		input := "someinput"
+		ouput, err := mockInformer.transformFunc(input)
+		assert.Nil(t, err)
+		outputStr, ok := ouput.(string)
+		assert.True(t, ok, "ouput from transform was expected to be a string")
+		assert.Equal(t, "someoutput", outputStr)
+
+		newInformer = cache.NewSharedIndexInformer
+	}})
+	tests = append(tests, testCase{description: "NewInformer() unable to set transform func", test: func(t *testing.T) {
+		dbClient := NewMockDBClient(gomock.NewController(t))
+		dynamicClient := NewMockResourceInterface(gomock.NewController(t))
+		mockInformer := mockInformer{
+			setTranformErr: fmt.Errorf("some error"),
+		}
+		testNewInformer := func(lw cache.ListerWatcher,
+			exampleObject runtime.Object,
+			defaultEventHandlerResyncPeriod time.Duration,
+			indexers cache.Indexers) cache.SharedIndexInformer {
+			return &mockInformer
+		}
+		newInformer = testNewInformer
+
+		fields := [][]string{{"something"}}
+		gvk := schema.GroupVersionKind{}
+
+		transformFunc := func(input interface{}) (interface{}, error) {
+			return "someoutput", nil
+		}
+		_, err := NewInformer(dynamicClient, fields, transformFunc, gvk, dbClient, false, true)
+		assert.Error(t, err)
+		newInformer = cache.NewSharedIndexInformer
+	}})
+
 	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) { test.test(t) })
@@ -198,7 +283,7 @@ func TestInformerListByOptions(t *testing.T) {
 	}
 }
 
-// Note: SQLite based caching uses an Informer that unsafely sets the Indexer as the ability to set it is not present 
+// Note: SQLite based caching uses an Informer that unsafely sets the Indexer as the ability to set it is not present
 // in client-go at the moment. Long term, we look forward contribute a patch to client-go to make that configurable.
 // Until then, we are adding this canary test that will panic in case the indexer cannot be set.
 func TestUnsafeSet(t *testing.T) {
@@ -226,4 +311,35 @@ func (dummyWatch) ResultChan() <-chan watch.Event {
 	result := make(chan watch.Event)
 	defer close(result)
 	return result
+}
+
+// mockInformer is a mock of cache.SharedIndexInformer. Unlike other types, we can't generate this using mockgen because we use a unsafeSet to replace the
+// indexer field, which is a struct field. This won't exist on the mock, producing an error. So we need to implement our own mock which actually has this field.
+type mockInformer struct {
+	transformFunc  cache.TransformFunc
+	setTranformErr error
+	indexer        cache.Indexer
+}
+
+func (m *mockInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (m *mockInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+func (m *mockInformer) RemoveEventHandler(handle cache.ResourceEventHandlerRegistration) error {
+	return nil
+}
+func (m *mockInformer) GetStore() cache.Store                                      { return nil }
+func (m *mockInformer) GetController() cache.Controller                            { return nil }
+func (m *mockInformer) Run(stopCh <-chan struct{})                                 {}
+func (m *mockInformer) HasSynced() bool                                            { return false }
+func (m *mockInformer) LastSyncResourceVersion() string                            { return "" }
+func (m *mockInformer) SetWatchErrorHandler(handler cache.WatchErrorHandler) error { return nil }
+func (m *mockInformer) IsStopped() bool                                            { return false }
+func (m *mockInformer) AddIndexers(indexers cache.Indexers) error                  { return nil }
+func (m *mockInformer) GetIndexer() cache.Indexer                                  { return nil }
+func (m *mockInformer) SetTransform(handler cache.TransformFunc) error {
+	m.transformFunc = handler
+	return m.setTranformErr
 }


### PR DESCRIPTION
Related to one of the tasks from rancher/rancher#45635. Adds the option for a `TransformFunc` which will be can be passed in when the Cache is created.