### PR TITLE
sql: when a query fails, add the query text in the error

### DIFF
--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -112,7 +112,7 @@ func (c *Client) Prepare(stmt string) *sql.Stmt {
 
 // QueryForRows queries the given stmt with the given params and returns the resulting rows. The query wil be retried
 // given a sqlite busy error.
-func (c *Client) QueryForRows(ctx context.Context, stmt transaction.Stmt, params ...any) (*sql.Rows, error) {
+func (c *Client) QueryForRows(ctx context.Context, query string, stmt transaction.Stmt, params ...any) (*sql.Rows, error) {
 	c.connLock.RLock()
 	defer c.connLock.RUnlock()
 	var rows *sql.Rows
@@ -125,7 +125,7 @@ func (c *Client) QueryForRows(ctx context.Context, stmt transaction.Stmt, params
 			if ok && sqlErr.Code() == sqlite3.SQLITE_BUSY {
 				return false, nil
 			}
-			return false, errors.Wrapf(err, "Error initializing Store DB")
+			return false, errors.Wrapf(err, "Error while running query: %s", query)
 		}
 		return true, nil
 	})

--- a/pkg/cache/sql/db/client_test.go
+++ b/pkg/cache/sql/db/client_test.go
@@ -66,7 +66,7 @@ func TestQueryForRows(t *testing.T) {
 		ctx := context.TODO()
 		r := &sql.Rows{}
 		s.EXPECT().QueryContext(ctx).Return(r, nil)
-		rows, err := client.QueryForRows(ctx, s)
+		rows, err := client.QueryForRows(ctx, "mocked query", s)
 		assert.Nil(t, err)
 		assert.Equal(t, r, rows)
 	},
@@ -77,7 +77,7 @@ func TestQueryForRows(t *testing.T) {
 		s := NewMockStmt(gomock.NewController(t))
 		ctx := context.TODO()
 		s.EXPECT().QueryContext(ctx).Return(nil, fmt.Errorf("error"))
-		_, err := client.QueryForRows(ctx, s)
+		_, err := client.QueryForRows(ctx, "mocked query", s)
 		assert.NotNil(t, err)
 	},
 	})

--- a/pkg/cache/sql/informer/factory/db_mocks_test.go
+++ b/pkg/cache/sql/informer/factory/db_mocks_test.go
@@ -35,6 +35,20 @@ func (m *MockTXClient) EXPECT() *MockTXClientMockRecorder {
 	return m.recorder
 }
 
+// Cancel mocks base method.
+func (m *MockTXClient) Cancel() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Cancel")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Cancel indicates an expected call of Cancel.
+func (mr *MockTXClientMockRecorder) Cancel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockTXClient)(nil).Cancel))
+}
+
 // Commit mocks base method.
 func (m *MockTXClient) Commit() error {
 	m.ctrl.T.Helper()

--- a/pkg/cache/sql/informer/factory/factory_mocks_test.go
+++ b/pkg/cache/sql/informer/factory/factory_mocks_test.go
@@ -95,10 +95,10 @@ func (mr *MockDBClientMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
 }
 
 // QueryForRows mocks base method.
-func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 transaction.Stmt, arg2 ...interface{}) (*sql.Rows, error) {
+func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 string, arg2 transaction.Stmt, arg3 ...interface{}) (*sql.Rows, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "QueryForRows", varargs...)
@@ -108,13 +108,13 @@ func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 transaction.Stmt,
 }
 
 // QueryForRows indicates an expected call of QueryForRows.
-func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockDBClient)(nil).QueryForRows), varargs...)
 }
 
-// QueryObjects mocks base method.
+// ReadObjects mocks base method.
 func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadObjects", arg0, arg1, arg2)
@@ -123,13 +123,13 @@ func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) (
 	return ret0, ret1
 }
 
-// QueryObjects indicates an expected call of QueryObjects.
-func (mr *MockDBClientMockRecorder) QueryObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ReadObjects indicates an expected call of ReadObjects.
+func (mr *MockDBClientMockRecorder) ReadObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadObjects", reflect.TypeOf((*MockDBClient)(nil).ReadObjects), arg0, arg1, arg2)
 }
 
-// QueryStrings mocks base method.
+// ReadStrings mocks base method.
 func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadStrings", arg0)
@@ -138,8 +138,8 @@ func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	return ret0, ret1
 }
 
-// QueryStrings indicates an expected call of QueryStrings.
-func (mr *MockDBClientMockRecorder) QueryStrings(arg0 interface{}) *gomock.Call {
+// ReadStrings indicates an expected call of ReadStrings.
+func (mr *MockDBClientMockRecorder) ReadStrings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStrings", reflect.TypeOf((*MockDBClient)(nil).ReadStrings), arg0)
 }

--- a/pkg/cache/sql/informer/indexer.go
+++ b/pkg/cache/sql/informer/indexer.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type DBClient interface {
 	Begin() (db.TXClient, error)
-	QueryForRows(ctx context.Context, stmt transaction.Stmt, params ...any) (*sql.Rows, error)
+	QueryForRows(ctx context.Context, query string, stmt transaction.Stmt, params ...any) (*sql.Rows, error)
 	ReadObjects(rows db.Rows, typ reflect.Type, shouldDecrypt bool) ([]any, error)
 	ReadStrings(rows db.Rows) ([]string, error)
 	Prepare(stmt string) *sql.Stmt
@@ -182,7 +182,7 @@ func (i *Indexer) Index(indexName string, obj any) ([]any, error) {
 		params = append(params, value)
 	}
 
-	rows, err := i.QueryForRows(context.TODO(), stmt, params...)
+	rows, err := i.QueryForRows(context.TODO(), query, stmt, params...)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (i *Indexer) Index(indexName string, obj any) ([]any, error) {
 // ByIndex returns the stored objects whose set of indexed values
 // for the named index includes the given indexed value
 func (i *Indexer) ByIndex(indexName, indexedValue string) ([]any, error) {
-	rows, err := i.QueryForRows(context.TODO(), i.listByIndexStmt, indexName, indexedValue)
+	rows, err := i.QueryForRows(context.TODO(), listByIndexFmt, i.listByIndexStmt, indexName, indexedValue)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (i *Indexer) IndexKeys(indexName, indexedValue string) ([]string, error) {
 		return nil, fmt.Errorf("Index with name %s does not exist", indexName)
 	}
 
-	rows, err := i.QueryForRows(context.TODO(), i.listKeysByIndexStmt, indexName, indexedValue)
+	rows, err := i.QueryForRows(context.TODO(), listKeyByIndexFmt, i.listKeysByIndexStmt, indexName, indexedValue)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (i *Indexer) ListIndexFuncValues(name string) []string {
 
 // safeListIndexFuncValues returns all the indexed values of the given index
 func (i *Indexer) safeListIndexFuncValues(indexName string) ([]string, error) {
-	rows, err := i.QueryForRows(context.TODO(), i.listIndexValuesStmt, indexName)
+	rows, err := i.QueryForRows(context.TODO(), listIndexValuesFmt, i.listIndexValuesStmt, indexName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/sql/informer/indexer_test.go
+++ b/pkg/cache/sql/informer/indexer_test.go
@@ -245,7 +245,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, nil)
@@ -270,7 +270,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject, testObject}, nil)
@@ -295,7 +295,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{}, nil)
@@ -338,7 +338,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
 		_, err := indexer.Index(indexName, testObject)
 		assert.NotNil(t, err)
 	}})
@@ -359,7 +359,7 @@ func TestIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, fmt.Errorf("error"))
@@ -386,7 +386,7 @@ func TestIndex(t *testing.T) {
 		store.EXPECT().GetName().Return("name")
 		stmt := &sql.Stmt{}
 		store.EXPECT().Prepare(fmt.Sprintf(selectQueryFmt, "name", ", ?")).Return(stmt)
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey, objKey+"2").Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey, objKey+"2").Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, nil)
@@ -421,7 +421,7 @@ func TestByIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, nil)
@@ -441,7 +441,7 @@ func TestByIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject, testObject}, nil)
@@ -461,7 +461,7 @@ func TestByIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{}, nil)
@@ -479,7 +479,7 @@ func TestByIndex(t *testing.T) {
 			listByIndexStmt: listStmt,
 		}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(nil, fmt.Errorf("error"))
 		_, err := indexer.ByIndex(indexName, objKey)
 		assert.NotNil(t, err)
 	}})
@@ -495,7 +495,7 @@ func TestByIndex(t *testing.T) {
 		}
 		testObject := testStoreObject{Id: "something", Val: "a"}
 
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listByIndexStmt, indexName, objKey).Return(rows, nil)
 		store.EXPECT().GetType().Return(reflect.TypeOf(testObject))
 		store.EXPECT().GetShouldEncrypt().Return(false)
 		store.EXPECT().ReadObjects(rows, reflect.TypeOf(testObject), false).Return([]any{testObject}, fmt.Errorf("error"))
@@ -525,7 +525,7 @@ func TestListIndexFuncValues(t *testing.T) {
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
 		store.EXPECT().ReadStrings(rows).Return([]string{"somestrings"}, nil)
 		vals := indexer.ListIndexFuncValues(indexName)
 		assert.Equal(t, []string{"somestrings"}, vals)
@@ -538,7 +538,7 @@ func TestListIndexFuncValues(t *testing.T) {
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listIndexValuesStmt, indexName).Return(nil, fmt.Errorf("error"))
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listIndexValuesStmt, indexName).Return(nil, fmt.Errorf("error"))
 		assert.Panics(t, func() { indexer.ListIndexFuncValues(indexName) })
 	}})
 	tests = append(tests, testCase{description: "ListIndexFuncvalues() with ReadStrings() error returned from store, should panic", test: func(t *testing.T) {
@@ -550,7 +550,7 @@ func TestListIndexFuncValues(t *testing.T) {
 			Store:           store,
 			listByIndexStmt: listStmt,
 		}
-		store.EXPECT().QueryForRows(context.TODO(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
+		store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), indexer.listIndexValuesStmt, indexName).Return(rows, nil)
 		store.EXPECT().ReadStrings(rows).Return([]string{"somestrings"}, fmt.Errorf("error"))
 		assert.Panics(t, func() { indexer.ListIndexFuncValues(indexName) })
 	}})

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -338,7 +338,7 @@ func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo ListOptions, p
 	// execute
 	prepStmt := l.Prepare(stmt)
 	defer l.CloseStmt(prepStmt)
-	rows, err := l.QueryForRows(ctx, prepStmt, params...)
+	rows, err := l.QueryForRows(ctx, stmt, prepStmt, params...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -184,6 +184,9 @@ func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo ListOptions, p
 		if err != nil {
 			return nil, "", err
 		}
+		if orClause == "" {
+			continue
+		}
 		whereClauses = append(whereClauses, orClause)
 		params = append(params, orParams...)
 	}

--- a/pkg/cache/sql/informer/listoption_indexer_test.go
+++ b/pkg/cache/sql/informer/listoption_indexer_test.go
@@ -192,8 +192,24 @@ func TestListByOptions(t *testing.T) {
   WHERE
     (FALSE)
   ORDER BY f."metadata.name" ASC `,
-		returnList:        []any{&unstructured.Unstructured{Object: unstrTestObjectMap}},
-		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{unstrTestObjectMap}}, Items: []unstructured.Unstructured{{Object: unstrTestObjectMap}}},
+		returnList:        []any{},
+		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{}}, Items: []unstructured.Unstructured{}},
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
+		description: "ListByOptions() with an empty filter, should not return an error",
+		listOptions: ListOptions{
+			Filters: []OrFilter{{[]Filter{}}},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN db2."something_fields" f ON o.key = f.key
+  WHERE
+    (FALSE)
+  ORDER BY f."metadata.name" ASC `,
+		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{}}, Items: []unstructured.Unstructured{}},
 		expectedContToken: "",
 		expectedErr:       nil,
 	})

--- a/pkg/cache/sql/informer/listoption_indexer_test.go
+++ b/pkg/cache/sql/informer/listoption_indexer_test.go
@@ -214,6 +214,23 @@ func TestListByOptions(t *testing.T) {
 		expectedErr:       nil,
 	})
 	tests = append(tests, testCase{
+		description: "ListByOptions() with an empty filter, should not return an error",
+		listOptions: ListOptions{
+			Filters: []OrFilter{{[]Filter{}}},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN db2."something_fields" f ON o.key = f.key
+  WHERE
+    (FALSE)
+  ORDER BY f."metadata.name" ASC `,
+		returnList:        []any{&unstructured.Unstructured{Object: unstrTestObjectMap}},
+		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{unstrTestObjectMap}}, Items: []unstructured.Unstructured{{Object: unstrTestObjectMap}}},
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
 		description: "ListByOptions with ChunkSize set should set limit in prepared sql.Stmt",
 		listOptions: ListOptions{ChunkSize: 2},
 		partitions:  []partition.Partition{},
@@ -684,9 +701,9 @@ func TestListByOptions(t *testing.T) {
 				fmt.Println(a)
 			}).Return(stmt)
 			if args := test.expectedStmtArgs; args != nil {
-				store.EXPECT().QueryForRows(context.TODO(), stmt, args...).Return(rows, nil)
+				store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), stmt, args...).Return(rows, nil)
 			} else {
-				store.EXPECT().QueryForRows(context.TODO(), stmt).Return(rows, nil)
+				store.EXPECT().QueryForRows(context.TODO(), gomock.Any(), stmt).Return(rows, nil)
 			}
 			store.EXPECT().GetType().Return(objType)
 			store.EXPECT().GetShouldEncrypt().Return(false)

--- a/pkg/cache/sql/informer/sql_mocks_test.go
+++ b/pkg/cache/sql/informer/sql_mocks_test.go
@@ -211,10 +211,10 @@ func (mr *MockStoreMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
 }
 
 // QueryForRows mocks base method.
-func (m *MockStore) QueryForRows(arg0 context.Context, arg1 transaction.Stmt, arg2 ...interface{}) (*sql.Rows, error) {
+func (m *MockStore) QueryForRows(arg0 context.Context, arg1 string, arg2 transaction.Stmt, arg3 ...interface{}) (*sql.Rows, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "QueryForRows", varargs...)
@@ -224,9 +224,9 @@ func (m *MockStore) QueryForRows(arg0 context.Context, arg1 transaction.Stmt, ar
 }
 
 // QueryForRows indicates an expected call of QueryForRows.
-func (mr *MockStoreMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) QueryForRows(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockStore)(nil).QueryForRows), varargs...)
 }
 

--- a/pkg/cache/sql/informer/store_mocks_test.go
+++ b/pkg/cache/sql/informer/store_mocks_test.go
@@ -81,10 +81,10 @@ func (mr *MockDBClientMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
 }
 
 // QueryForRows mocks base method.
-func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 transaction.Stmt, arg2 ...interface{}) (*sql.Rows, error) {
+func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 string, arg2 transaction.Stmt, arg3 ...interface{}) (*sql.Rows, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "QueryForRows", varargs...)
@@ -94,13 +94,13 @@ func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 transaction.Stmt,
 }
 
 // QueryForRows indicates an expected call of QueryForRows.
-func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockDBClient)(nil).QueryForRows), varargs...)
 }
 
-// QueryObjects mocks base method.
+// ReadObjects mocks base method.
 func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadObjects", arg0, arg1, arg2)
@@ -109,13 +109,13 @@ func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) (
 	return ret0, ret1
 }
 
-// QueryObjects indicates an expected call of QueryObjects.
-func (mr *MockDBClientMockRecorder) QueryObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ReadObjects indicates an expected call of ReadObjects.
+func (mr *MockDBClientMockRecorder) ReadObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadObjects", reflect.TypeOf((*MockDBClient)(nil).ReadObjects), arg0, arg1, arg2)
 }
 
-// QueryStrings mocks base method.
+// ReadStrings mocks base method.
 func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadStrings", arg0)
@@ -124,8 +124,8 @@ func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	return ret0, ret1
 }
 
-// QueryStrings indicates an expected call of QueryStrings.
-func (mr *MockDBClientMockRecorder) QueryStrings(arg0 interface{}) *gomock.Call {
+// ReadStrings indicates an expected call of ReadStrings.
+func (mr *MockDBClientMockRecorder) ReadStrings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStrings", reflect.TypeOf((*MockDBClient)(nil).ReadStrings), arg0)
 }

--- a/pkg/cache/sql/store/store_mocks_test.go
+++ b/pkg/cache/sql/store/store_mocks_test.go
@@ -81,10 +81,10 @@ func (mr *MockDBClientMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
 }
 
 // QueryForRows mocks base method.
-func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 transaction.Stmt, arg2 ...interface{}) (*sql.Rows, error) {
+func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 string, arg2 transaction.Stmt, arg3 ...interface{}) (*sql.Rows, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "QueryForRows", varargs...)
@@ -94,9 +94,9 @@ func (m *MockDBClient) QueryForRows(arg0 context.Context, arg1 transaction.Stmt,
 }
 
 // QueryForRows indicates an expected call of QueryForRows.
-func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockDBClient)(nil).QueryForRows), varargs...)
 }
 

--- a/pkg/cache/sql/store/store_test.go
+++ b/pkg/cache/sql/store/store_test.go
@@ -316,7 +316,7 @@ func TestList(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listStmt).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{}, nil)
 		items := store.List()
 		assert.Len(t, items, 0)
@@ -327,7 +327,7 @@ func TestList(t *testing.T) {
 		store := SetupStore(t, c, shouldEncrypt)
 		fakeItemsToReturn := []any{"something1", 2, false}
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listStmt).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(fakeItemsToReturn, nil)
 		items := store.List()
 		assert.Equal(t, fakeItemsToReturn, items)
@@ -337,7 +337,7 @@ func TestList(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listStmt).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(nil, fmt.Errorf("error"))
 		defer func() {
 			recover()
@@ -366,7 +366,7 @@ func TestListKeys(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{"a", "b", "c"}, nil)
 		keys := store.ListKeys()
 		assert.Len(t, keys, 3)
@@ -377,7 +377,7 @@ func TestListKeys(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
 		keys := store.ListKeys()
 		assert.Len(t, keys, 0)
@@ -403,7 +403,7 @@ func TestGet(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{testObject}, nil)
 		item, exists, err := store.Get(testObject)
 		assert.Nil(t, err)
@@ -415,7 +415,7 @@ func TestGet(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{}, nil)
 		item, exists, err := store.Get(testObject)
 		assert.Nil(t, err)
@@ -427,7 +427,7 @@ func TestGet(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(nil, fmt.Errorf("error"))
 		_, _, err := store.Get(testObject)
 		assert.NotNil(t, err)
@@ -453,7 +453,7 @@ func TestGetByKey(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{testObject}, nil)
 		item, exists, err := store.GetByKey(testObject.Id)
 		assert.Nil(t, err)
@@ -465,7 +465,7 @@ func TestGetByKey(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return([]any{}, nil)
 		item, exists, err := store.GetByKey(testObject.Id)
 		assert.Nil(t, err)
@@ -477,7 +477,7 @@ func TestGetByKey(t *testing.T) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().QueryForRows(context.TODO(), store.getStmt, testObject.Id).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.getStmt, testObject.Id).Return(r, nil)
 		c.EXPECT().ReadObjects(r, reflect.TypeOf(testObject), store.shouldEncrypt).Return(nil, fmt.Errorf("error"))
 		_, _, err := store.GetByKey(testObject.Id)
 		assert.NotNil(t, err)
@@ -507,7 +507,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 		c.EXPECT().Begin().Return(txC, nil)
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(store.deleteStmt)
 		txC.EXPECT().StmtExec(store.deleteStmt, testObject.Id)
@@ -523,7 +523,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 		c.EXPECT().Begin().Return(tx, nil)
 		tx.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{}, nil)
 		c.EXPECT().Upsert(tx, store.upsertStmt, testObject.Id, testObject, store.shouldEncrypt)
 		tx.EXPECT().Commit()
@@ -545,7 +545,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 		c.EXPECT().Begin().Return(tx, nil)
 		tx.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
 		err := store.Replace([]any{testObject}, testObject.Id)
 		assert.NotNil(t, err)
@@ -557,7 +557,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 		c.EXPECT().Begin().Return(tx, nil)
 		tx.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
 		err := store.Replace([]any{testObject}, testObject.Id)
 		assert.NotNil(t, err)
@@ -569,7 +569,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 		c.EXPECT().Begin().Return(txC, nil)
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(store.deleteStmt)
 		txC.EXPECT().StmtExec(store.deleteStmt, testObject.Id).Return(fmt.Errorf("error"))
@@ -583,7 +583,7 @@ func TestReplace(t *testing.T) {
 		r := &sql.Rows{}
 		c.EXPECT().Begin().Return(txC, nil)
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
-		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
+		c.EXPECT().QueryForRows(context.TODO(), gomock.Any(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(store.deleteStmt)
 		txC.EXPECT().StmtExec(store.deleteStmt, testObject.Id).Return(nil)


### PR DESCRIPTION
This makes debugging easier, especially with integration tests.

Best reviewed commit-by-commit.

*Note* this is based on top of https://github.com/rancher/lasso/pull/82. Ignore the first commit while reviewing