### PR TITLE
sql: listoption_indexer: handle the case with one empty filter correctly

### DIFF
--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -184,6 +184,9 @@ func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo ListOptions, p
 		if err != nil {
 			return nil, "", err
 		}
+		if orClause == "" {
+			continue
+		}
 		whereClauses = append(whereClauses, orClause)
 		params = append(params, orParams...)
 	}

--- a/pkg/cache/sql/informer/listoption_indexer_test.go
+++ b/pkg/cache/sql/informer/listoption_indexer_test.go
@@ -192,8 +192,24 @@ func TestListByOptions(t *testing.T) {
   WHERE
     (FALSE)
   ORDER BY f."metadata.name" ASC `,
-		returnList:        []any{&unstructured.Unstructured{Object: unstrTestObjectMap}},
-		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{unstrTestObjectMap}}, Items: []unstructured.Unstructured{{Object: unstrTestObjectMap}}},
+		returnList:        []any{},
+		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{}}, Items: []unstructured.Unstructured{}},
+		expectedContToken: "",
+		expectedErr:       nil,
+	})
+	tests = append(tests, testCase{
+		description: "ListByOptions() with an empty filter, should not return an error",
+		listOptions: ListOptions{
+			Filters: []OrFilter{{[]Filter{}}},
+		},
+		partitions: []partition.Partition{},
+		ns:         "",
+		expectedStmt: `SELECT o.object, o.objectnonce, o.dekid FROM "something" o
+  JOIN db2."something_fields" f ON o.key = f.key
+  WHERE
+    (FALSE)
+  ORDER BY f."metadata.name" ASC `,
+		expectedList:      &unstructured.UnstructuredList{Object: map[string]interface{}{"items": []map[string]interface{}{}}, Items: []unstructured.Unstructured{}},
 		expectedContToken: "",
 		expectedErr:       nil,
 	})


### PR DESCRIPTION
Integration tests revealed this case result in error 500 because an incorrect query is produced in this case (`WHERE ()`).

This adds a test and addresses the case.