### PR TITLE
sql: teach ListByOptions to return the total object count

### DIFF
--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -125,7 +125,7 @@ func (c *Client) QueryForRows(ctx context.Context, stmt transaction.Stmt, params
 			if ok && sqlErr.Code() == sqlite3.SQLITE_BUSY {
 				return false, nil
 			}
-			return false, errors.Wrapf(err, "Error initializing Store DB")
+			return false, err
 		}
 		return true, nil
 	})

--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/gob"
+	"fmt"
 	"os"
 	"reflect"
 	"sync"
@@ -251,7 +252,7 @@ func toBytes(obj any) []byte {
 	enc := gob.NewEncoder(&buf)
 	err := enc.Encode(obj)
 	if err != nil {
-		panic(errors.Wrap(err, "Error while gobbing object"))
+		panic(fmt.Errorf("error while gobbing object: %w", err))
 	}
 	bb := buf.Bytes()
 	return bb
@@ -269,7 +270,7 @@ func fromBytes(buf sql.RawBytes, typ reflect.Type) (reflect.Value, error) {
 func closeRowsOnError(rows Rows, err error) error {
 	ce := rows.Close()
 	if ce != nil {
-		return errors.Wrap(ce, "while handling "+err.Error())
+		return fmt.Errorf("error in closing rows while handling %s: %w", err.Error(), ce)
 	}
 
 	return err

--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -201,6 +201,34 @@ func (c *Client) ReadStrings(rows Rows) ([]string, error) {
 	return result, nil
 }
 
+// ReadInt scans the first of the given rows into a single int (eg. for COUNT() queries)
+func (c *Client) ReadInt(rows Rows) (int, error) {
+	c.connLock.RLock()
+	defer c.connLock.RUnlock()
+
+	if !rows.Next() {
+		return 0, closeRowsOnError(rows, sql.ErrNoRows)
+	}
+
+	var result int
+	err := rows.Scan(&result)
+	if err != nil {
+		return 0, closeRowsOnError(rows, err)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return 0, closeRowsOnError(rows, err)
+	}
+
+	err = rows.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	return result, nil
+}
+
 // Begin attempt to begin a transaction, and returns it along with a function for unlocking the
 // database once the transaction is done.
 func (c *Client) Begin() (TXClient, error) {

--- a/pkg/cache/sql/informer/factory/db_mocks_test.go
+++ b/pkg/cache/sql/informer/factory/db_mocks_test.go
@@ -35,6 +35,20 @@ func (m *MockTXClient) EXPECT() *MockTXClientMockRecorder {
 	return m.recorder
 }
 
+// Cancel mocks base method.
+func (m *MockTXClient) Cancel() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Cancel")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Cancel indicates an expected call of Cancel.
+func (mr *MockTXClientMockRecorder) Cancel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockTXClient)(nil).Cancel))
+}
+
 // Commit mocks base method.
 func (m *MockTXClient) Commit() error {
 	m.ctrl.T.Helper()

--- a/pkg/cache/sql/informer/factory/factory_mocks_test.go
+++ b/pkg/cache/sql/informer/factory/factory_mocks_test.go
@@ -114,7 +114,22 @@ func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockDBClient)(nil).QueryForRows), varargs...)
 }
 
-// QueryObjects mocks base method.
+// ReadInt mocks base method.
+func (m *MockDBClient) ReadInt(arg0 db.Rows) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadInt", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadInt indicates an expected call of ReadInt.
+func (mr *MockDBClientMockRecorder) ReadInt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadInt", reflect.TypeOf((*MockDBClient)(nil).ReadInt), arg0)
+}
+
+// ReadObjects mocks base method.
 func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadObjects", arg0, arg1, arg2)
@@ -123,13 +138,13 @@ func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) (
 	return ret0, ret1
 }
 
-// QueryObjects indicates an expected call of QueryObjects.
-func (mr *MockDBClientMockRecorder) QueryObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ReadObjects indicates an expected call of ReadObjects.
+func (mr *MockDBClientMockRecorder) ReadObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadObjects", reflect.TypeOf((*MockDBClient)(nil).ReadObjects), arg0, arg1, arg2)
 }
 
-// QueryStrings mocks base method.
+// ReadStrings mocks base method.
 func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadStrings", arg0)
@@ -138,8 +153,8 @@ func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	return ret0, ret1
 }
 
-// QueryStrings indicates an expected call of QueryStrings.
-func (mr *MockDBClientMockRecorder) QueryStrings(arg0 interface{}) *gomock.Call {
+// ReadStrings indicates an expected call of ReadStrings.
+func (mr *MockDBClientMockRecorder) ReadStrings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStrings", reflect.TypeOf((*MockDBClient)(nil).ReadStrings), arg0)
 }

--- a/pkg/cache/sql/informer/indexer.go
+++ b/pkg/cache/sql/informer/indexer.go
@@ -79,6 +79,7 @@ type DBClient interface {
 	QueryForRows(ctx context.Context, stmt transaction.Stmt, params ...any) (*sql.Rows, error)
 	ReadObjects(rows db.Rows, typ reflect.Type, shouldDecrypt bool) ([]any, error)
 	ReadStrings(rows db.Rows) ([]string, error)
+	ReadInt(rows db.Rows) (int, error)
 	Prepare(stmt string) *sql.Stmt
 	CloseStmt(stmt db.Closable) error
 }

--- a/pkg/cache/sql/informer/indexer.go
+++ b/pkg/cache/sql/informer/indexer.go
@@ -99,12 +99,12 @@ func NewIndexer(indexers cache.Indexers, s Store) (*Indexer, error) {
 	createTableQuery := fmt.Sprintf(createTableFmt, db.Sanitize(s.GetName()))
 	err = tx.Exec(createTableQuery)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while executing query:\n %s", createTableQuery)
+		return nil, fmt.Errorf("while executing query: %s got error: %w", createTableQuery, err)
 	}
 	createIndexQuery := fmt.Sprintf(createIndexFmt, db.Sanitize(s.GetName()))
 	err = tx.Exec(createIndexQuery)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while executing query:\n %s", createIndexQuery)
+		return nil, fmt.Errorf("while executing query: %s got error: %w", createIndexQuery, err)
 	}
 	err = tx.Commit()
 	if err != nil {
@@ -139,7 +139,7 @@ func (i *Indexer) AfterUpsert(key string, obj any, tx db.TXClient) error {
 	// delete all
 	err := tx.StmtExec(tx.Stmt(i.deleteIndicesStmt), key)
 	if err != nil {
-		return errors.Wrapf(err, "Error while executing query:\n %s", i.deleteIndicesQuery)
+		return fmt.Errorf("while executing query: %s got error: %w", i.deleteIndicesQuery, err)
 	}
 
 	// re-insert all
@@ -154,7 +154,7 @@ func (i *Indexer) AfterUpsert(key string, obj any, tx db.TXClient) error {
 		for _, value := range values {
 			err = tx.StmtExec(tx.Stmt(i.addIndexStmt), indexName, value, key)
 			if err != nil {
-				return errors.Wrapf(err, "Error while executing query:\n %s", i.addIndexQuery)
+				return fmt.Errorf("while executing query: %s got error: %w", i.addIndexQuery, err)
 			}
 		}
 	}
@@ -199,7 +199,7 @@ func (i *Indexer) Index(indexName string, obj any) ([]any, error) {
 
 	rows, err := i.QueryForRows(context.TODO(), stmt, params...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while executing query:\n %s", query)
+		return nil, fmt.Errorf("while executing query: %s got error: %w", query, err)
 	}
 	return i.ReadObjects(rows, i.GetType(), i.GetShouldEncrypt())
 }
@@ -209,7 +209,7 @@ func (i *Indexer) Index(indexName string, obj any) ([]any, error) {
 func (i *Indexer) ByIndex(indexName, indexedValue string) ([]any, error) {
 	rows, err := i.QueryForRows(context.TODO(), i.listByIndexStmt, indexName, indexedValue)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while executing query:\n %s", i.listByIndexQuery)
+		return nil, fmt.Errorf("while executing query: %s got error: %w", i.listByIndexQuery, err)
 	}
 	return i.ReadObjects(rows, i.GetType(), i.GetShouldEncrypt())
 }
@@ -225,7 +225,7 @@ func (i *Indexer) IndexKeys(indexName, indexedValue string) ([]string, error) {
 
 	rows, err := i.QueryForRows(context.TODO(), i.listKeysByIndexStmt, indexName, indexedValue)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while executing query:\n %s", i.listKeysByIndexQuery)
+		return nil, fmt.Errorf("while executing query: %s got error: %w", i.listKeysByIndexQuery, err)
 	}
 	return i.ReadStrings(rows)
 }
@@ -243,7 +243,7 @@ func (i *Indexer) ListIndexFuncValues(name string) []string {
 func (i *Indexer) safeListIndexFuncValues(indexName string) ([]string, error) {
 	rows, err := i.QueryForRows(context.TODO(), i.listIndexValuesStmt, indexName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while executing query:\n %s", i.listIndexValuesQuery)
+		return nil, fmt.Errorf("while executing query: %s got error: %w", i.listIndexValuesQuery, err)
 	}
 	return i.ReadStrings(rows)
 }

--- a/pkg/cache/sql/informer/informer.go
+++ b/pkg/cache/sql/informer/informer.go
@@ -26,7 +26,7 @@ type Informer struct {
 }
 
 type ByOptionsLister interface {
-	ListByOptions(ctx context.Context, lo ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, string, error)
+	ListByOptions(ctx context.Context, lo ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error)
 }
 
 // NewInformer returns a new SQLite-backed Informer for the type specified by schema in unstructured.Unstructured form
@@ -71,9 +71,13 @@ func NewInformer(client dynamic.ResourceInterface, fields [][]string, gvk schema
 	}, nil
 }
 
-// ListByOptions returns objects according to the specified list options and partitions
-// see ListOptionIndexer.ListByOptions
-func (i *Informer) ListByOptions(ctx context.Context, lo ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, string, error) {
+// ListByOptions returns objects according to the specified list options and partitions.
+// Specifically:
+//   - an unstructured list of resources belonging to any of the specified partitions
+//   - the total number of resources (returned list might be a subset depending on pagination options in lo)
+//   - a continue token, if there are more pages after the returned one
+//   - an error instead of all of the above if anything went wrong
+func (i *Informer) ListByOptions(ctx context.Context, lo ListOptions, partitions []partition.Partition, namespace string) (*unstructured.UnstructuredList, int, string, error) {
 	return i.ByOptionsLister.ListByOptions(ctx, lo, partitions, namespace)
 }
 

--- a/pkg/cache/sql/informer/informer_mocks_test.go
+++ b/pkg/cache/sql/informer/informer_mocks_test.go
@@ -37,13 +37,14 @@ func (m *MockByOptionsLister) EXPECT() *MockByOptionsListerMockRecorder {
 }
 
 // ListByOptions mocks base method.
-func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, string, error) {
+func (m *MockByOptionsLister) ListByOptions(arg0 context.Context, arg1 ListOptions, arg2 []partition.Partition, arg3 string) (*unstructured.UnstructuredList, int, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListByOptions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.UnstructuredList)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // ListByOptions indicates an expected call of ListByOptions.

--- a/pkg/cache/sql/informer/informer_test.go
+++ b/pkg/cache/sql/informer/informer_test.go
@@ -167,11 +167,13 @@ func TestInformerListByOptions(t *testing.T) {
 				Object: map[string]interface{}{"s": 2},
 			}},
 		}
+		expectedTotal := len(expectedList.Items)
 		expectedContinueToken := "123"
-		indexer.EXPECT().ListByOptions(context.TODO(), lo, partitions, ns).Return(expectedList, expectedContinueToken, nil)
-		list, continueToken, err := informer.ListByOptions(context.TODO(), lo, partitions, ns)
+		indexer.EXPECT().ListByOptions(context.TODO(), lo, partitions, ns).Return(expectedList, expectedTotal, expectedContinueToken, nil)
+		list, total, continueToken, err := informer.ListByOptions(context.TODO(), lo, partitions, ns)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedList, list)
+		assert.Equal(t, len(expectedList.Items), total)
 		assert.Equal(t, expectedContinueToken, continueToken)
 	}})
 	tests = append(tests, testCase{description: "ListByOptions() with indexer ListByOptions error, should return error", test: func(t *testing.T) {
@@ -182,8 +184,8 @@ func TestInformerListByOptions(t *testing.T) {
 		lo := ListOptions{}
 		var partitions []partition.Partition
 		ns := "somens"
-		indexer.EXPECT().ListByOptions(context.TODO(), lo, partitions, ns).Return(nil, "", fmt.Errorf("error"))
-		_, _, err := informer.ListByOptions(context.TODO(), lo, partitions, ns)
+		indexer.EXPECT().ListByOptions(context.TODO(), lo, partitions, ns).Return(nil, 0, "", fmt.Errorf("error"))
+		_, _, _, err := informer.ListByOptions(context.TODO(), lo, partitions, ns)
 		assert.NotNil(t, err)
 	}})
 	t.Parallel()

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -383,8 +383,6 @@ func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo ListOptions, p
 		if err != nil {
 			return nil, 0, "", err
 		}
-	} else {
-		total = len(items)
 	}
 
 	continueToken := ""

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -152,7 +152,7 @@ func (l *ListOptionIndexer) afterUpsert(key string, obj any, tx db.TXClient) err
 			logrus.Errorf("cannot index object of type [%s] with key [%s] for indexer [%s]: %v", l.GetType().String(), key, l.GetName(), err)
 			cErr := tx.Cancel()
 			if cErr != nil {
-				return errors.Wrap(err, cErr.Error())
+				return fmt.Errorf("could not cancel transaction: %s while recovering from error: %w", cErr.Error(), err)
 			}
 			return err
 		}
@@ -170,7 +170,7 @@ func (l *ListOptionIndexer) afterUpsert(key string, obj any, tx db.TXClient) err
 
 	err := tx.StmtExec(tx.Stmt(l.addFieldStmt), args...)
 	if err != nil {
-		return errors.Wrapf(err, "Error while executing query:\n %s", l.addFieldQuery)
+		return fmt.Errorf("while executing query: %s got error: %w", l.addFieldQuery, err)
 	}
 	return nil
 }
@@ -180,7 +180,7 @@ func (l *ListOptionIndexer) afterDelete(key string, tx db.TXClient) error {
 
 	err := tx.StmtExec(tx.Stmt(l.deleteFieldStmt), args...)
 	if err != nil {
-		return errors.Wrapf(err, "Error while executing query:\n %s", l.deleteFieldQuery)
+		return fmt.Errorf("while executing query: %s got error: %w", l.deleteFieldQuery, err)
 	}
 	return nil
 }
@@ -357,7 +357,7 @@ func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo ListOptions, p
 	defer l.CloseStmt(stmt)
 	rows, err := l.QueryForRows(ctx, stmt, params...)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "Error while executing query:\n %s", query)
+		return nil, "", fmt.Errorf("while executing query: %s got error: %w", query, err)
 	}
 	items, err := l.ReadObjects(rows, l.GetType(), l.GetShouldEncrypt())
 	if err != nil {
@@ -380,7 +380,7 @@ func (l *ListOptionIndexer) validateColumn(column string) error {
 			return nil
 		}
 	}
-	return errors.Wrapf(InvalidColumnErr, "column is invalid [%s]", column)
+	return fmt.Errorf("column is invalid [%s]: %w", column, InvalidColumnErr)
 }
 
 // buildORClause creates an SQLite compatible query that ORs conditions built from passed filters

--- a/pkg/cache/sql/informer/sql_mocks_test.go
+++ b/pkg/cache/sql/informer/sql_mocks_test.go
@@ -230,6 +230,21 @@ func (mr *MockStoreMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockStore)(nil).QueryForRows), varargs...)
 }
 
+// ReadInt mocks base method.
+func (m *MockStore) ReadInt(arg0 db.Rows) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadInt", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadInt indicates an expected call of ReadInt.
+func (mr *MockStoreMockRecorder) ReadInt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadInt", reflect.TypeOf((*MockStore)(nil).ReadInt), arg0)
+}
+
 // ReadObjects mocks base method.
 func (m *MockStore) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) ([]interface{}, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cache/sql/informer/store_mocks_test.go
+++ b/pkg/cache/sql/informer/store_mocks_test.go
@@ -100,7 +100,22 @@ func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockDBClient)(nil).QueryForRows), varargs...)
 }
 
-// QueryObjects mocks base method.
+// ReadInt mocks base method.
+func (m *MockDBClient) ReadInt(arg0 db.Rows) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadInt", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadInt indicates an expected call of ReadInt.
+func (mr *MockDBClientMockRecorder) ReadInt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadInt", reflect.TypeOf((*MockDBClient)(nil).ReadInt), arg0)
+}
+
+// ReadObjects mocks base method.
 func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadObjects", arg0, arg1, arg2)
@@ -109,13 +124,13 @@ func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) (
 	return ret0, ret1
 }
 
-// QueryObjects indicates an expected call of QueryObjects.
-func (mr *MockDBClientMockRecorder) QueryObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ReadObjects indicates an expected call of ReadObjects.
+func (mr *MockDBClientMockRecorder) ReadObjects(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadObjects", reflect.TypeOf((*MockDBClient)(nil).ReadObjects), arg0, arg1, arg2)
 }
 
-// QueryStrings mocks base method.
+// ReadStrings mocks base method.
 func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadStrings", arg0)
@@ -124,8 +139,8 @@ func (m *MockDBClient) ReadStrings(arg0 db.Rows) ([]string, error) {
 	return ret0, ret1
 }
 
-// QueryStrings indicates an expected call of QueryStrings.
-func (mr *MockDBClientMockRecorder) QueryStrings(arg0 interface{}) *gomock.Call {
+// ReadStrings indicates an expected call of ReadStrings.
+func (mr *MockDBClientMockRecorder) ReadStrings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStrings", reflect.TypeOf((*MockDBClient)(nil).ReadStrings), arg0)
 }

--- a/pkg/cache/sql/store/store.go
+++ b/pkg/cache/sql/store/store.go
@@ -63,6 +63,7 @@ type DBClient interface {
 	QueryForRows(ctx context.Context, stmt transaction.Stmt, params ...any) (*sql.Rows, error)
 	ReadObjects(rows db.Rows, typ reflect.Type, shouldDecrypt bool) ([]any, error)
 	ReadStrings(rows db.Rows) ([]string, error)
+	ReadInt(rows db.Rows) (int, error)
 	Upsert(tx db.TXClient, stmt *sql.Stmt, key string, obj any, shouldEncrypt bool) error
 	CloseStmt(closable db.Closable) error
 }

--- a/pkg/cache/sql/store/store_mocks_test.go
+++ b/pkg/cache/sql/store/store_mocks_test.go
@@ -100,6 +100,21 @@ func (mr *MockDBClientMockRecorder) QueryForRows(arg0, arg1 interface{}, arg2 ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryForRows", reflect.TypeOf((*MockDBClient)(nil).QueryForRows), varargs...)
 }
 
+// ReadInt mocks base method.
+func (m *MockDBClient) ReadInt(arg0 db.Rows) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadInt", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadInt indicates an expected call of ReadInt.
+func (mr *MockDBClientMockRecorder) ReadInt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadInt", reflect.TypeOf((*MockDBClient)(nil).ReadInt), arg0)
+}
+
 // ReadObjects mocks base method.
 func (m *MockDBClient) ReadObjects(arg0 db.Rows, arg1 reflect.Type, arg2 bool) ([]interface{}, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
*Problem*: ListByOptions is currently unable to return the total object count (it will only return the requested page), and Steve needs it for the UI.

This PR adds the lasso bits, the accompanying Steve PR https://github.com/rancher/steve/pull/236 adds the Steve specific bits.

FWIW I have also run the integration tests and they are all green https://github.com/rancher/rancher/pull/46015

**Best reviewed commit-by-commit.**

**Please note this contains commits from https://github.com/rancher/lasso/pull/83, disregard the first two commits.**

**Please note this PR should be merged before https://github.com/rancher/steve/pull/236.**