### PR TITLE
sql: rationalization of parameter sanitization

### DIFF
--- a/pkg/cache/sql/informer/indexer.go
+++ b/pkg/cache/sql/informer/indexer.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/rancher/lasso/pkg/cache/sql/db"
 	"github.com/rancher/lasso/pkg/cache/sql/db/transaction"
 	"k8s.io/client-go/tools/cache"
@@ -86,13 +85,6 @@ type DBClient interface {
 
 // NewIndexer returns a cache.Indexer backed by SQLite for objects of the given example type
 func NewIndexer(indexers cache.Indexers, s Store) (*Indexer, error) {
-	// sanity checks first
-	for key := range indexers {
-		if strings.Contains(key, `"`) || strings.Contains(key, `'`) {
-			return nil, errors.Errorf("Quote characters (\") or (') in indexer names are not supported")
-		}
-	}
-
 	tx, err := s.Begin()
 	if err != nil {
 		return nil, err

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -433,7 +433,7 @@ func (l *ListOptionIndexer) buildORClauseFromFilters(orFilters OrFilter) (string
 
 // toColumnName returns the column name corresponding to a field expressed as string slice
 func toColumnName(s []string) string {
-	return strings.Join(s, ".")
+	return db.Sanitize(strings.Join(s, "."))
 }
 
 // getField extracts the value of a field expressed as a string path from an unstructured object

--- a/pkg/cache/sql/store/store.go
+++ b/pkg/cache/sql/store/store.go
@@ -71,7 +71,7 @@ type DBClient interface {
 // NewStore creates a SQLite-backed cache.Store for objects of the given example type
 func NewStore(example any, keyFunc cache.KeyFunc, c DBClient, shouldEncrypt bool, name string) (*Store, error) {
 	s := &Store{
-		name:          db.Sanitize(name),
+		name:          name,
 		typ:           reflect.TypeOf(example),
 		DBClient:      c,
 		keyFunc:       keyFunc,
@@ -85,7 +85,7 @@ func NewStore(example any, keyFunc cache.KeyFunc, c DBClient, shouldEncrypt bool
 	if err != nil {
 		return nil, err
 	}
-	createTableQuery := fmt.Sprintf(createTableFmt, s.name)
+	createTableQuery := fmt.Sprintf(createTableFmt, db.Sanitize(s.name))
 	err = txC.Exec(createTableQuery)
 	if err != nil {
 		return nil, fmt.Errorf("while executing query: %s got error: %w", createTableQuery, err)
@@ -96,11 +96,11 @@ func NewStore(example any, keyFunc cache.KeyFunc, c DBClient, shouldEncrypt bool
 		return nil, err
 	}
 
-	s.upsertQuery = fmt.Sprintf(upsertStmtFmt, s.name)
-	s.deleteQuery = fmt.Sprintf(deleteStmtFmt, s.name)
-	s.getQuery = fmt.Sprintf(getStmtFmt, s.name)
-	s.listQuery = fmt.Sprintf(listStmtFmt, s.name)
-	s.listKeysQuery = fmt.Sprintf(listKeysStmtFmt, s.name)
+	s.upsertQuery = fmt.Sprintf(upsertStmtFmt, db.Sanitize(s.name))
+	s.deleteQuery = fmt.Sprintf(deleteStmtFmt, db.Sanitize(s.name))
+	s.getQuery = fmt.Sprintf(getStmtFmt, db.Sanitize(s.name))
+	s.listQuery = fmt.Sprintf(listStmtFmt, db.Sanitize(s.name))
+	s.listKeysQuery = fmt.Sprintf(listKeysStmtFmt, db.Sanitize(s.name))
 
 	s.upsertStmt = s.Prepare(s.upsertQuery)
 	s.deleteStmt = s.Prepare(s.deleteQuery)


### PR DESCRIPTION
This prevents SQL injections even if a user is using lasso standalone as a client library.

This PR is meant to conclude conversations started here:
 - https://github.com/rancher/lasso/pull/65#discussion_r1622389185
 - https://github.com/rancher/lasso/pull/65#discussion_r1611626853


General posture is:
 - use parameters (`?`) wherever possible
 - Two cases fall outside of this category: table names and column names. Using parameters for them is not possible because the query planner needs to know them in order to prepare the query (unlike parameter values)
 	- column names: we pick them from a list, they are not free parameters
 	- table names: are sanitized

To make the last point as easy to audit as possible, I deliberately took a very pedantic approach here - sanitizing right before formatting the SQL string. This makes it easy to spot missing `db.Sanitize` calls in searches like this:


![Screenshot 2024-07-05 at 17 01 28](https://github.com/rancher/lasso/assets/250541/0eef1e26-e46c-4d6e-b8cb-a93f2af8e042)

Please note this contains commits from https://github.com/rancher/lasso/pull/84, disregard the first commits.
