### PR TITLE
Expose metrics registration function

### DIFF
--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -12,20 +12,39 @@ const metricsEnv = "CATTLE_PROMETHEUS_METRICS"
 
 func init() {
 	if os.Getenv(metricsEnv) == "true" {
-		prometheusMetrics = true
-		prometheus.MustRegister(
-			TotalControllerExecutions,
-			TotalCachedObjects,
-			reconcileTime,
-			// expose workqueue metrics
-			depth,
-			adds,
-			latency,
-			workDuration,
-			unfinished,
-			longestRunningProcessor,
-			retries,
-		)
-		workqueue.SetProvider(workqueueMetricsProvider{})
+		MustRegisterWithWorkqueue(prometheus.DefaultRegisterer)
 	}
+}
+
+// MustRegisterWithWorkqueue registers all metrics, including Kubernetes internal
+// workqueue metrics, with the provided registerer
+func MustRegisterWithWorkqueue(registerer prometheus.Registerer) {
+	prometheusMetrics = true
+	registerer.MustRegister(
+		TotalControllerExecutions,
+		TotalCachedObjects,
+		reconcileTime,
+		// expose workqueue metrics
+		depth,
+		adds,
+		latency,
+		workDuration,
+		unfinished,
+		longestRunningProcessor,
+		retries,
+	)
+	workqueue.SetProvider(workqueueMetricsProvider{})
+}
+
+// MustRegister registers only lasso-specific metrics.
+// This must be used if attempting to register Lasso metrics to the same
+// registerer as used by Kubernetes itself, otherwise prometheus will panic
+// when both packages register metrics with the same name.
+func MustRegister(registerer prometheus.Registerer) {
+	prometheusMetrics = true
+	registerer.MustRegister(
+		TotalControllerExecutions,
+		TotalCachedObjects,
+		reconcileTime,
+	)
 }


### PR DESCRIPTION
Allows exposing metrics via a custom registerer, instead of forcing the use of prometheus.DefaultRegisterer. Also allows initializing metrics outside of init() which is generally considered an anti-pattern.

The default behavior of calling` prometheus.DefaultRegisterer.MustRegister()` is retained, ref:
https://github.com/prometheus/client_golang/blob/fec6b222d9ac46f61b0194fd343d5a10bf1e1d09/prometheus/registry.go#L174-L178

I also had to add a function to avoid registering the kubernetes internal workqueue metrics, to prevent conflicts in k3s where kubernetes itself registers those in the same process:
https://github.com/rancher/lasso/blob/32d96874d344eeeed641df40bdd38c50ad0213e7/pkg/metrics/workqueue.go#L21-L22