### PR TITLE
Fix Param logging output

### DIFF
--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -356,7 +356,7 @@ func (l *ListOptionIndexer) ListByOptions(ctx context.Context, lo ListOptions, p
 	query += limitClause
 	query += offsetClause
 	logrus.Debugf("ListOptionIndexer prepared statement: %v", query)
-	logrus.Debugf("Params: %v", params...)
+	logrus.Debugf("Params: %v", params)
 
 	// execute
 	stmt := l.Prepare(query)


### PR DESCRIPTION
Because it was expanding the slice for a variadic function the first
value in the params was being used for the %v and the remainder of the
slice was treated as EXTRA see https://pkg.go.dev/fmt#hdr-Format_errors.