### PR TITLE
sql: use WAL mode and set pragmas correctly

### DIFF
--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -332,7 +332,7 @@ func (c *Client) NewConnection() error {
 		return err
 	}
 
-	sqlDB, err := sql.Open("sqlite", "file:"+InformerObjectCacheDBPath+"?mode=rwc&cache=shared&_journal_mode=wal&_synchronous=off&_foreign_keys=on&_busy_timeout=1000000")
+	sqlDB, err := sql.Open("sqlite", "file:"+InformerObjectCacheDBPath+"?mode=rwc&_pragma=journal_mode=wal&_pragma=synchronous=off&_pragma=foreign_keys=on&_pragma=busy_timeout=1000000")
 	if err != nil {
 		return err
 	}

--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -332,7 +332,7 @@ func (c *Client) NewConnection() error {
 		return err
 	}
 
-	sqlDB, err := sql.Open("sqlite", "file:"+InformerObjectCacheDBPath+"?mode=rwc&_pragma=journal_mode=wal&_pragma=synchronous=off&_pragma=foreign_keys=on&_pragma=busy_timeout=1000000")
+	sqlDB, err := sql.Open("sqlite", "file:"+InformerObjectCacheDBPath+"?mode=rwc&_pragma=journal_mode=wal&_pragma=synchronous=off&_pragma=foreign_keys=on&_pragma=busy_timeout=120000")
 	if err != nil {
 		return err
 	}

--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -311,7 +311,18 @@ func (c *Client) NewConnection() error {
 		return err
 	}
 
-	sqlDB, err := sql.Open("sqlite", "file:"+InformerObjectCacheDBPath+"?mode=rwc&_pragma=journal_mode=wal&_pragma=synchronous=off&_pragma=foreign_keys=on&_pragma=busy_timeout=120000")
+	sqlDB, err := sql.Open("sqlite", "file:"+InformerObjectCacheDBPath+"?"+
+		// open SQLite file in read-write mode, creating it if it does not exist
+		"mode=rwc&"+
+		// use the WAL journal mode for consistency and efficiency
+		"_pragma=journal_mode=wal&"+
+		// do not even attempt to attain durability. Database is thrown away at pod restart
+		"_pragma=synchronous=off&"+
+		// do check foreign keys and honor ON DELETE CASCADE
+		"_pragma=foreign_keys=on&"+
+		// if two transactions want to write at the same time, allow 2 minutes for the first to complete
+		// before baling out
+		"_pragma=busy_timeout=120000"+
 	if err != nil {
 		return err
 	}

--- a/pkg/cache/sql/db/db_mocks_test.go
+++ b/pkg/cache/sql/db/db_mocks_test.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	context "context"
 	sql "database/sql"
 	reflect "reflect"
 
@@ -123,19 +124,19 @@ func (m *MockConnection) EXPECT() *MockConnectionMockRecorder {
 	return m.recorder
 }
 
-// Begin mocks base method.
-func (m *MockConnection) Begin() (*sql.Tx, error) {
+// BeginTx mocks base method.
+func (m *MockConnection) BeginTx(arg0 context.Context, arg1 *sql.TxOptions) (*sql.Tx, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Begin")
+	ret := m.ctrl.Call(m, "BeginTx", arg0, arg1)
 	ret0, _ := ret[0].(*sql.Tx)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Begin indicates an expected call of Begin.
-func (mr *MockConnectionMockRecorder) Begin() *gomock.Call {
+// BeginTx indicates an expected call of BeginTx.
+func (mr *MockConnectionMockRecorder) BeginTx(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockConnection)(nil).Begin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTx", reflect.TypeOf((*MockConnection)(nil).BeginTx), arg0, arg1)
 }
 
 // Close mocks base method.

--- a/pkg/cache/sql/informer/factory/factory_mocks_test.go
+++ b/pkg/cache/sql/informer/factory/factory_mocks_test.go
@@ -42,19 +42,19 @@ func (m *MockDBClient) EXPECT() *MockDBClientMockRecorder {
 	return m.recorder
 }
 
-// Begin mocks base method.
-func (m *MockDBClient) Begin() (db.TXClient, error) {
+// BeginTx mocks base method.
+func (m *MockDBClient) BeginTx(arg0 context.Context, arg1 bool) (db.TXClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Begin")
+	ret := m.ctrl.Call(m, "BeginTx", arg0, arg1)
 	ret0, _ := ret[0].(db.TXClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Begin indicates an expected call of Begin.
-func (mr *MockDBClientMockRecorder) Begin() *gomock.Call {
+// BeginTx indicates an expected call of BeginTx.
+func (mr *MockDBClientMockRecorder) BeginTx(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockDBClient)(nil).Begin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTx", reflect.TypeOf((*MockDBClient)(nil).BeginTx), arg0, arg1)
 }
 
 // CloseStmt mocks base method.

--- a/pkg/cache/sql/informer/indexer.go
+++ b/pkg/cache/sql/informer/indexer.go
@@ -74,7 +74,7 @@ type Store interface {
 }
 
 type DBClient interface {
-	Begin() (db.TXClient, error)
+	BeginTx(ctx context.Context, forWriting bool) (db.TXClient, error)
 	QueryForRows(ctx context.Context, stmt transaction.Stmt, params ...any) (*sql.Rows, error)
 	ReadObjects(rows db.Rows, typ reflect.Type, shouldDecrypt bool) ([]any, error)
 	ReadStrings(rows db.Rows) ([]string, error)
@@ -85,7 +85,7 @@ type DBClient interface {
 
 // NewIndexer returns a cache.Indexer backed by SQLite for objects of the given example type
 func NewIndexer(indexers cache.Indexers, s Store) (*Indexer, error) {
-	tx, err := s.Begin()
+	tx, err := s.BeginTx(context.Background(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/sql/informer/indexer_test.go
+++ b/pkg/cache/sql/informer/indexer_test.go
@@ -45,7 +45,7 @@ func TestNewIndexer(t *testing.T) {
 			},
 		}
 		storeName := "someStoreName"
-		store.EXPECT().Begin().Return(client, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(client, nil)
 		store.EXPECT().GetName().AnyTimes().Return(storeName)
 		client.EXPECT().Exec(fmt.Sprintf(createTableFmt, storeName, storeName)).Return(nil)
 		client.EXPECT().Exec(fmt.Sprintf(createIndexFmt, storeName, storeName)).Return(nil)
@@ -69,7 +69,7 @@ func TestNewIndexer(t *testing.T) {
 				return []string{objKey}, nil
 			},
 		}
-		store.EXPECT().Begin().Return(nil, fmt.Errorf("error"))
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(nil, fmt.Errorf("error"))
 		_, err := NewIndexer(indexers, store)
 		assert.NotNil(t, err)
 	}})
@@ -84,7 +84,7 @@ func TestNewIndexer(t *testing.T) {
 			},
 		}
 		storeName := "someStoreName"
-		store.EXPECT().Begin().Return(client, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(client, nil)
 		store.EXPECT().GetName().AnyTimes().Return(storeName)
 		client.EXPECT().Exec(fmt.Sprintf(createTableFmt, storeName, storeName)).Return(fmt.Errorf("error"))
 		_, err := NewIndexer(indexers, store)
@@ -101,7 +101,7 @@ func TestNewIndexer(t *testing.T) {
 			},
 		}
 		storeName := "someStoreName"
-		store.EXPECT().Begin().Return(client, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(client, nil)
 		store.EXPECT().GetName().AnyTimes().Return(storeName)
 		client.EXPECT().Exec(fmt.Sprintf(createTableFmt, storeName, storeName)).Return(nil)
 		client.EXPECT().Exec(fmt.Sprintf(createIndexFmt, storeName, storeName)).Return(fmt.Errorf("error"))
@@ -119,7 +119,7 @@ func TestNewIndexer(t *testing.T) {
 			},
 		}
 		storeName := "someStoreName"
-		store.EXPECT().Begin().Return(client, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(client, nil)
 		store.EXPECT().GetName().AnyTimes().Return(storeName)
 		client.EXPECT().Exec(fmt.Sprintf(createTableFmt, storeName, storeName)).Return(nil)
 		client.EXPECT().Exec(fmt.Sprintf(createIndexFmt, storeName, storeName)).Return(nil)

--- a/pkg/cache/sql/informer/informer_test.go
+++ b/pkg/cache/sql/informer/informer_test.go
@@ -40,21 +40,21 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 		dbClient.EXPECT().Prepare(gomock.Any()).Return(&sql.Stmt{}).AnyTimes()
 
 		// NewIndexer() logic (within NewListOptionIndexer(). This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(context.Background(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -77,7 +77,7 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(fmt.Errorf("error"))
 
@@ -94,14 +94,14 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 		dbClient.EXPECT().Prepare(gomock.Any()).Return(&sql.Stmt{}).AnyTimes()
 
 		// NewIndexer() logic (within NewListOptionIndexer(). This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(fmt.Errorf("error"))
@@ -119,21 +119,21 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 		dbClient.EXPECT().Prepare(gomock.Any()).Return(&sql.Stmt{}).AnyTimes()
 
 		// NewIndexer() logic (within NewListOptionIndexer(). This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -162,21 +162,21 @@ func TestNewInformer(t *testing.T) {
 
 		// NewStore() from store package logic. This package is only concerned with whether it returns err or not as NewStore
 		// is tested in depth in its own package.
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 		dbClient.EXPECT().Prepare(gomock.Any()).Return(&sql.Stmt{}).AnyTimes()
 
 		// NewIndexer() logic (within NewListOptionIndexer(). This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Commit().Return(nil)
 
 		// NewListOptionIndexer() logic. This test is only concerned with whether it returns err or not as NewIndexer
 		// is tested in depth in its own indexer_test.go
-		dbClient.EXPECT().Begin().Return(txClient, nil)
+		dbClient.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -89,7 +89,7 @@ func NewListOptionIndexer(fields [][]string, s Store, namespaced bool) (*ListOpt
 		columnDefs[index] = column
 	}
 
-	tx, err := l.Begin()
+	tx, err := l.BeginTx(context.Background(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/sql/informer/listoption_indexer_test.go
+++ b/pkg/cache/sql/informer/listoption_indexer_test.go
@@ -35,7 +35,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		id := "somename"
 		stmt := &sql.Stmt{}
 		// logic for NewIndexer(), only interested in if this results in error or not
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		store.EXPECT().GetName().Return(id).AnyTimes()
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -47,7 +47,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().RegisterAfterUpsert(gomock.Any())
 		store.EXPECT().RegisterAfterDelete(gomock.Any())
 
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		// create field table
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsTableFmt, id, `"metadata.name" TEXT, "metadata.creationTimestamp" TEXT, "metadata.namespace" TEXT, "something" TEXT`)).Return(nil)
 		// create field table indexes
@@ -67,7 +67,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		fields := [][]string{{"something"}}
 		id := "somename"
 		// logic for NewIndexer(), only interested in if this results in error or not
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		store.EXPECT().GetName().Return(id).AnyTimes()
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -83,7 +83,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		id := "somename"
 		stmt := &sql.Stmt{}
 		// logic for NewIndexer(), only interested in if this results in error or not
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		store.EXPECT().GetName().Return(id).AnyTimes()
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -95,7 +95,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().RegisterAfterUpsert(gomock.Any())
 		store.EXPECT().RegisterAfterDelete(gomock.Any())
 
-		store.EXPECT().Begin().Return(txClient, fmt.Errorf("error"))
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, fmt.Errorf("error"))
 
 		_, err := NewListOptionIndexer(fields, store, false)
 		assert.NotNil(t, err)
@@ -107,7 +107,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		id := "somename"
 		stmt := &sql.Stmt{}
 		// logic for NewIndexer(), only interested in if this results in error or not
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		store.EXPECT().GetName().Return(id).AnyTimes()
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -119,7 +119,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().RegisterAfterUpsert(gomock.Any())
 		store.EXPECT().RegisterAfterDelete(gomock.Any())
 
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsTableFmt, id, `"metadata.name" TEXT, "metadata.creationTimestamp" TEXT, "metadata.namespace" TEXT, "something" TEXT`)).Return(nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.name", id, "metadata.name")).Return(fmt.Errorf("error"))
 
@@ -133,7 +133,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		id := "somename"
 		stmt := &sql.Stmt{}
 		// logic for NewIndexer(), only interested in if this results in error or not
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		store.EXPECT().GetName().Return(id).AnyTimes()
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
 		txClient.EXPECT().Exec(gomock.Any(), gomock.Any()).Return(nil)
@@ -145,7 +145,7 @@ func TestNewListOptionIndexer(t *testing.T) {
 		store.EXPECT().RegisterAfterUpsert(gomock.Any())
 		store.EXPECT().RegisterAfterDelete(gomock.Any())
 
-		store.EXPECT().Begin().Return(txClient, nil)
+		store.EXPECT().BeginTx(gomock.Any(), true).Return(txClient, nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsTableFmt, id, `"metadata.name" TEXT, "metadata.creationTimestamp" TEXT, "metadata.namespace" TEXT, "something" TEXT`)).Return(nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.name", id, "metadata.name")).Return(nil)
 		txClient.EXPECT().Exec(fmt.Sprintf(createFieldsIndexFmt, id, "metadata.namespace", id, "metadata.namespace")).Return(nil)

--- a/pkg/cache/sql/informer/sql_mocks_test.go
+++ b/pkg/cache/sql/informer/sql_mocks_test.go
@@ -56,19 +56,19 @@ func (mr *MockStoreMockRecorder) Add(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockStore)(nil).Add), arg0)
 }
 
-// Begin mocks base method.
-func (m *MockStore) Begin() (db.TXClient, error) {
+// BeginTx mocks base method.
+func (m *MockStore) BeginTx(arg0 context.Context, arg1 bool) (db.TXClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Begin")
+	ret := m.ctrl.Call(m, "BeginTx", arg0, arg1)
 	ret0, _ := ret[0].(db.TXClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Begin indicates an expected call of Begin.
-func (mr *MockStoreMockRecorder) Begin() *gomock.Call {
+// BeginTx indicates an expected call of BeginTx.
+func (mr *MockStoreMockRecorder) BeginTx(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockStore)(nil).Begin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTx", reflect.TypeOf((*MockStore)(nil).BeginTx), arg0, arg1)
 }
 
 // CloseStmt mocks base method.

--- a/pkg/cache/sql/informer/store_mocks_test.go
+++ b/pkg/cache/sql/informer/store_mocks_test.go
@@ -42,19 +42,19 @@ func (m *MockDBClient) EXPECT() *MockDBClientMockRecorder {
 	return m.recorder
 }
 
-// Begin mocks base method.
-func (m *MockDBClient) Begin() (db.TXClient, error) {
+// BeginTx mocks base method.
+func (m *MockDBClient) BeginTx(arg0 context.Context, arg1 bool) (db.TXClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Begin")
+	ret := m.ctrl.Call(m, "BeginTx", arg0, arg1)
 	ret0, _ := ret[0].(db.TXClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Begin indicates an expected call of Begin.
-func (mr *MockDBClientMockRecorder) Begin() *gomock.Call {
+// BeginTx indicates an expected call of BeginTx.
+func (mr *MockDBClientMockRecorder) BeginTx(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockDBClient)(nil).Begin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTx", reflect.TypeOf((*MockDBClient)(nil).BeginTx), arg0, arg1)
 }
 
 // CloseStmt mocks base method.

--- a/pkg/cache/sql/store/store_mocks_test.go
+++ b/pkg/cache/sql/store/store_mocks_test.go
@@ -42,19 +42,19 @@ func (m *MockDBClient) EXPECT() *MockDBClientMockRecorder {
 	return m.recorder
 }
 
-// Begin mocks base method.
-func (m *MockDBClient) Begin() (db.TXClient, error) {
+// BeginTx mocks base method.
+func (m *MockDBClient) BeginTx(arg0 context.Context, arg1 bool) (db.TXClient, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Begin")
+	ret := m.ctrl.Call(m, "BeginTx", arg0, arg1)
 	ret0, _ := ret[0].(db.TXClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Begin indicates an expected call of Begin.
-func (mr *MockDBClientMockRecorder) Begin() *gomock.Call {
+// BeginTx indicates an expected call of BeginTx.
+func (mr *MockDBClientMockRecorder) BeginTx(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Begin", reflect.TypeOf((*MockDBClient)(nil).Begin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTx", reflect.TypeOf((*MockDBClient)(nil).BeginTx), arg0, arg1)
 }
 
 // CloseStmt mocks base method.

--- a/pkg/cache/sql/store/store_test.go
+++ b/pkg/cache/sql/store/store_test.go
@@ -50,7 +50,7 @@ func TestAdd(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with no DB Client errors", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 		txC.EXPECT().Commit().Return(nil)
 		err := store.Add(testObject)
@@ -62,7 +62,7 @@ func TestAdd(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with no DB Client errors and an afterUpsert function", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		txC.EXPECT().Commit().Return(nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 
@@ -80,7 +80,7 @@ func TestAdd(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with no DB Client errors and an afterUpsert function that returns error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 		store.afterUpsert = append(store.afterUpsert, func(key string, object any, txC db.TXClient) error {
 			return fmt.Errorf("error")
@@ -91,9 +91,9 @@ func TestAdd(t *testing.T) {
 	},
 	})
 
-	tests = append(tests, testCase{description: "Add with DB Client Begin() error", test: func(t *testing.T, shouldEncrypt bool) {
+	tests = append(tests, testCase{description: "Add with DB Client BeginTx(gomock.Any(), true) error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, _ := SetupMockDB(t)
-		c.EXPECT().Begin().Return(nil, fmt.Errorf("failed"))
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(nil, fmt.Errorf("failed"))
 
 		store := SetupStore(t, c, shouldEncrypt)
 		err := store.Add(testObject)
@@ -103,7 +103,7 @@ func TestAdd(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with DB Client Upsert() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(fmt.Errorf("failed"))
 		err := store.Add(testObject)
 		assert.NotNil(t, err)
@@ -112,7 +112,7 @@ func TestAdd(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with DB Client Upsert() error with following Rollback() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(fmt.Errorf("failed"))
 		err := store.Add(testObject)
 		assert.NotNil(t, err)
@@ -121,7 +121,7 @@ func TestAdd(t *testing.T) {
 	tests = append(tests, testCase{description: "Add with DB Client Commit() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 		txC.EXPECT().Commit().Return(fmt.Errorf("failed"))
 
@@ -151,7 +151,7 @@ func TestUpdate(t *testing.T) {
 	tests = append(tests, testCase{description: "Update with no DB Client errors", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 		txC.EXPECT().Commit().Return(nil)
 		err := store.Update(testObject)
@@ -163,7 +163,7 @@ func TestUpdate(t *testing.T) {
 	tests = append(tests, testCase{description: "Update with no DB Client errors and an afterUpsert function", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 		txC.EXPECT().Commit().Return(nil)
 
@@ -181,7 +181,7 @@ func TestUpdate(t *testing.T) {
 	tests = append(tests, testCase{description: "Update with no DB Client errors and an afterUpsert function that returns error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 
 		store.afterUpsert = append(store.afterUpsert, func(key string, object any, txC db.TXClient) error {
@@ -192,9 +192,9 @@ func TestUpdate(t *testing.T) {
 	},
 	})
 
-	tests = append(tests, testCase{description: "Update with DB Client Begin() error", test: func(t *testing.T, shouldEncrypt bool) {
+	tests = append(tests, testCase{description: "Update with DB Client BeginTx(gomock.Any(), true) error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, _ := SetupMockDB(t)
-		c.EXPECT().Begin().Return(nil, fmt.Errorf("failed"))
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(nil, fmt.Errorf("failed"))
 
 		store := SetupStore(t, c, shouldEncrypt)
 		err := store.Update(testObject)
@@ -204,7 +204,7 @@ func TestUpdate(t *testing.T) {
 	tests = append(tests, testCase{description: "Update with DB Client Upsert() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(fmt.Errorf("failed"))
 		err := store.Update(testObject)
 		assert.NotNil(t, err)
@@ -213,7 +213,7 @@ func TestUpdate(t *testing.T) {
 	tests = append(tests, testCase{description: "Update with DB Client Upsert() error with following Rollback() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(fmt.Errorf("failed"))
 		err := store.Update(testObject)
 		assert.NotNil(t, err)
@@ -222,7 +222,7 @@ func TestUpdate(t *testing.T) {
 	tests = append(tests, testCase{description: "Update with DB Client Commit() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		c.EXPECT().Upsert(txC, store.upsertStmt, "something", testObject, store.shouldEncrypt).Return(nil)
 		txC.EXPECT().Commit().Return(fmt.Errorf("failed"))
 
@@ -252,7 +252,7 @@ func TestDelete(t *testing.T) {
 	tests = append(tests, testCase{description: "Delete with no DB Client errors", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		// deleteStmt here will be an empty string since Prepare mock returns an empty *sql.Stmt
 		txC.EXPECT().Stmt(store.deleteStmt).Return(store.deleteStmt)
 		txC.EXPECT().StmtExec(store.deleteStmt, testObject.Id).Return(nil)
@@ -261,10 +261,10 @@ func TestDelete(t *testing.T) {
 		assert.Nil(t, err)
 	},
 	})
-	tests = append(tests, testCase{description: "Delete with DB Client Begin() error", test: func(t *testing.T, shouldEncrypt bool) {
+	tests = append(tests, testCase{description: "Delete with DB Client BeginTx(gomock.Any(), true) error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(nil, fmt.Errorf("error"))
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(nil, fmt.Errorf("error"))
 		// deleteStmt here will be an empty string since Prepare mock returns an empty *sql.Stmt
 		err := store.Delete(testObject)
 		assert.NotNil(t, err)
@@ -273,7 +273,7 @@ func TestDelete(t *testing.T) {
 	tests = append(tests, testCase{description: "Delete with TX Client StmtExec() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		txC.EXPECT().Stmt(store.deleteStmt).Return(store.deleteStmt)
 		txC.EXPECT().StmtExec(store.deleteStmt, testObject.Id).Return(fmt.Errorf("error"))
 		// deleteStmt here will be an empty string since Prepare mock returns an empty *sql.Stmt
@@ -284,7 +284,7 @@ func TestDelete(t *testing.T) {
 	tests = append(tests, testCase{description: "Delete with DB Client Commit() error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		// deleteStmt here will be an empty string since Prepare mock returns an empty *sql.Stmt
 		txC.EXPECT().Stmt(store.deleteStmt).Return(store.deleteStmt)
 		// tx.EXPECT().
@@ -505,7 +505,7 @@ func TestReplace(t *testing.T) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
 		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
@@ -521,7 +521,7 @@ func TestReplace(t *testing.T) {
 		c, tx := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().Begin().Return(tx, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(tx, nil)
 		tx.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
 		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{}, nil)
@@ -531,10 +531,10 @@ func TestReplace(t *testing.T) {
 		assert.Nil(t, err)
 	},
 	})
-	tests = append(tests, testCase{description: "Replace with DB Client Begin() error", test: func(t *testing.T, shouldEncrypt bool) {
+	tests = append(tests, testCase{description: "Replace with DB Client BeginTx(gomock.Any(), true) error", test: func(t *testing.T, shouldEncrypt bool) {
 		c, _ := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
-		c.EXPECT().Begin().Return(nil, fmt.Errorf("error"))
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(nil, fmt.Errorf("error"))
 		err := store.Replace([]any{testObject}, testObject.Id)
 		assert.NotNil(t, err)
 	},
@@ -543,7 +543,7 @@ func TestReplace(t *testing.T) {
 		c, tx := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().Begin().Return(tx, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(tx, nil)
 		tx.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
 		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
@@ -555,7 +555,7 @@ func TestReplace(t *testing.T) {
 		c, tx := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().Begin().Return(tx, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(tx, nil)
 		tx.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
 		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return(nil, fmt.Errorf("error"))
@@ -567,7 +567,7 @@ func TestReplace(t *testing.T) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
 		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
@@ -581,7 +581,7 @@ func TestReplace(t *testing.T) {
 		c, txC := SetupMockDB(t)
 		store := SetupStore(t, c, shouldEncrypt)
 		r := &sql.Rows{}
-		c.EXPECT().Begin().Return(txC, nil)
+		c.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 		txC.EXPECT().Stmt(store.listKeysStmt).Return(store.listKeysStmt)
 		c.EXPECT().QueryForRows(context.TODO(), store.listKeysStmt).Return(r, nil)
 		c.EXPECT().ReadStrings(r).Return([]string{testObject.Id}, nil)
@@ -629,7 +629,7 @@ func SetupMockDB(t *testing.T) (*MockDBClient, *MockTXClient) {
 	// stmt := NewMockStmt(gomock.NewController())
 	txC.EXPECT().Exec(fmt.Sprintf(createTableFmt, "testStoreObject")).Return(nil)
 	txC.EXPECT().Commit().Return(nil)
-	dbC.EXPECT().Begin().Return(txC, nil)
+	dbC.EXPECT().BeginTx(gomock.Any(), true).Return(txC, nil)
 
 	// use stmt mock here
 	dbC.EXPECT().Prepare(fmt.Sprintf(upsertStmtFmt, "testStoreObject")).Return(&sql.Stmt{})


### PR DESCRIPTION
This 
 - sets PRAGMAs correctly, before they were ignored as they used a wrong syntax
 - removes the `shared=cache` option as https://github.com/rancher/lasso/pull/97 removed the need for it
 - removes the mechanism retrying on SQLITE_BUSY, which is then unnecessary
 - adds code to issue `BEGIN` on read-only transactions and `BEGIN IMMEDIATE` for transactions expected to write

The last point is necessary in order to avoid `SQLITE_BUSY` (5) errors in presence of multiple concurrent writing transactions. Without it `busy_timeout` would not be sufficient, see discussion below.

_best reviewed commit-by-commit_


# Benchmark notes

Results from a quick and rough benchmark on my dev environment look good - performance is on par or superior compared to the situation without this PR.

This test lists the first page of ConfigMaps with a varying number of ConfigMaps: 0 up to 6000. Also, a number of ConfigMaps are changed (added and deleted) every second: 0 up to 400.

Results are the p(95) of the whole request time:

![image](https://github.com/user-attachments/assets/356409c1-bd83-43db-ad4f-4ac7339f6950)

_(Grey is without this PR, green is with this PR. Lower is better)_

Note 1: the test at 6000 ConfigMaps failed with a SQLite error after 100 changes per second: this PR also fixes that bug 😇 

Note 2: results are also robustly better than running with Vai off (no SQLite pagination):

![image](https://github.com/user-attachments/assets/2cfe9002-f679-49b8-b363-1bddf3b39dfa)

_(Grey is without this PR, green is with this PR, red is with Vai off. Lower is better)_


To replicate use:
https://gist.github.com/moio/20a43fa406432cec5fc8aee0394d3e1f

With these scripts from the dartboard project:

https://github.com/rancher/dartboard/blob/main/k6/api_benchmark.js
https://github.com/rancher/dartboard/blob/main/k6/create_k8s_resources.js
https://github.com/rancher/dartboard/blob/main/k6/change_config_maps.js
