### PR TITLE
sql: remove obsolete options

### DIFF
--- a/pkg/cache/sql/db/client.go
+++ b/pkg/cache/sql/db/client.go
@@ -340,12 +340,6 @@ func (c *Client) NewConnection() error {
 		return err
 	}
 
-	// necessary to prevent memory races. Otherwise, all connections will close and in-memory database for fields table
-	// will be closed automatically. Setting max connections also minimizes SQLITE_BUSY errors.
-	// https://github.com/mattn/go-sqlite3/blob/master/README.md#faq
-	sqlDB.SetConnMaxIdleTime(-1)
-	sqlDB.SetConnMaxLifetime(-1)
-
 	c.conn = sqlDB
 	return nil
 }


### PR DESCRIPTION
This is to remove options that only make sense when in-memory SQLite was an option.