### PR TITLE
Replace primary/secondary sort fields with an array of sort directives.

### DIFF
--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -382,6 +382,9 @@ func (l *ListOptionIndexer) constructQuery(lo ListOptions, partitions []partitio
 	}
 
 	// 3- Sorting: ORDER BY clauses (from lo.Sort)
+	if len(lo.Sort.Fields) != len(lo.Sort.Orders) {
+		return nil, 0, "", fmt.Errorf("sort fields length %d != sort orders length %d", len(lo.Sort.Fields), len(lo.Sort.Orders))
+	}
 	if len(lo.Sort.Fields) > 0 {
 		orderByClauses := []string{}
 		for i, field := range lo.Sort.Fields {

--- a/pkg/cache/sql/informer/listoption_indexer.go
+++ b/pkg/cache/sql/informer/listoption_indexer.go
@@ -381,9 +381,14 @@ func (l *ListOptionIndexer) constructQuery(lo ListOptions, partitions []partitio
 		}
 	}
 
+	// before proceeding, save a copy of the query and params without LIMIT/OFFSET/ORDER info
+	// for COUNTing all results later
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM (%s)", query)
+	countParams := params[:]
+
 	// 3- Sorting: ORDER BY clauses (from lo.Sort)
 	if len(lo.Sort.Fields) != len(lo.Sort.Orders) {
-		return nil, 0, "", fmt.Errorf("sort fields length %d != sort orders length %d", len(lo.Sort.Fields), len(lo.Sort.Orders))
+		return nil, fmt.Errorf("sort fields length %d != sort orders length %d", len(lo.Sort.Fields), len(lo.Sort.Orders))
 	}
 	if len(lo.Sort.Fields) > 0 {
 		orderByClauses := []string{}

--- a/pkg/cache/sql/informer/listoptions.go
+++ b/pkg/cache/sql/informer/listoptions.go
@@ -55,11 +55,10 @@ type OrFilter struct {
 // The subfield to sort by is represented in a request query using . notation, e.g. 'metadata.name'.
 // The subfield is internally represented as a slice, e.g. [metadata, name].
 // The order is represented by prefixing the sort key by '-', e.g. sort=-metadata.name.
+// e.g. To sort internal clusters first followed by clusters in alpha order: sort=-spec.internal,spec.displayName
 type Sort struct {
-	PrimaryField   []string
-	SecondaryField []string
-	PrimaryOrder   SortOrder
-	SecondaryOrder SortOrder
+	Fields [][]string
+	Orders []SortOrder
 }
 
 // Pagination represents how to return paginated results.


### PR DESCRIPTION
This allows collection URLs to have a sort query that sorts on more than two fields

The use of `PrimaryField` and `SecondaryField` is too limiting, and leads to unlikely edge-cases,
like having a Secondary Field but no Primary Field. Better to just maintain parallel arrays of 
fields and sort-orders.

Related to [#48092](https://github.com/rancher/rancher/issues/48092)