### PR TITLE
Add "ctx" label to lasso handler metrics

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -50,6 +50,7 @@ type controller struct {
 	startLock sync.Mutex
 
 	name        string
+	ctxID       string
 	workqueue   workqueue.RateLimitingInterface
 	rateLimiter workqueue.RateLimiter
 	informer    cache.SharedIndexInformer
@@ -174,6 +175,7 @@ func (c *controller) Start(ctx context.Context, workers int) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
+	c.ctxID = metrics.ContextID(ctx)
 	go c.run(workers, ctx.Done())
 	c.started = true
 	return nil
@@ -226,7 +228,7 @@ func (c *controller) processSingleItem(obj interface{}) error {
 func (c *controller) syncHandler(key string) error {
 	obj, exists, err := c.informer.GetStore().GetByKey(key)
 	if err != nil {
-		metrics.IncTotalHandlerExecutions(c.name, "", true)
+		metrics.IncTotalHandlerExecutions(c.ctxID, c.name, "", true)
 		return err
 	}
 	if !exists {

--- a/pkg/controller/sharedcontroller.go
+++ b/pkg/controller/sharedcontroller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/lasso/pkg/cache"
 	"github.com/rancher/lasso/pkg/client"
+	"github.com/rancher/lasso/pkg/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cachetools "k8s.io/client-go/tools/cache"
@@ -93,6 +94,7 @@ func (s *sharedController) Start(ctx context.Context, workers int) error {
 		return nil
 	}
 
+	s.handler.CtxID = metrics.ContextID(ctx)
 	if err := s.controller.Start(ctx, workers); err != nil {
 		return err
 	}

--- a/pkg/controller/sharedcontrollerfactory.go
+++ b/pkg/controller/sharedcontrollerfactory.go
@@ -182,7 +182,7 @@ func (s *sharedControllerFactory) ForResourceKind(gvr schema.GroupVersionResourc
 
 	client := s.sharedCacheFactory.SharedClientFactory().ForResourceKind(gvr, kind, namespaced)
 
-	handler := &SharedHandler{controllerGVR: gvr.String()}
+	handler := &SharedHandler{ControllerName: gvr.String()}
 
 	controllerResult = &sharedController{
 		deferredController: func() (Controller, error) {

--- a/pkg/controller/sharedhandler.go
+++ b/pkg/controller/sharedhandler.go
@@ -26,9 +26,13 @@ type handlerEntry struct {
 }
 
 type SharedHandler struct {
+	// Used for metrics recording
+	// They are exported because this SharedHandler is sometimes embedded used as a field in other packages, like dynamic
+	ControllerName string
+	CtxID          string
+
 	// keep first because arm32 needs atomic.AddInt64 target to be mem aligned
-	idCounter     int64
-	controllerGVR string
+	idCounter int64
 
 	lock     sync.RWMutex
 	handlers []handlerEntry
@@ -80,9 +84,9 @@ func (h *SharedHandler) OnChange(key string, obj runtime.Object) error {
 			})
 			hasError = true
 		}
-		metrics.IncTotalHandlerExecutions(h.controllerGVR, handler.name, hasError)
+		metrics.IncTotalHandlerExecutions(h.CtxID, h.ControllerName, handler.name, hasError)
 		reconcileTime := time.Since(reconcileStartTS)
-		metrics.ReportReconcileTime(h.controllerGVR, handler.name, hasError, reconcileTime.Seconds())
+		metrics.ReportReconcileTime(h.CtxID, h.ControllerName, handler.name, hasError, reconcileTime.Seconds())
 
 		if newObj != nil && !reflect.ValueOf(newObj).IsNil() {
 			meta, err := meta.Accessor(newObj)

--- a/pkg/dynamic/controller.go
+++ b/pkg/dynamic/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/lasso/pkg/client"
 	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/lasso/pkg/log"
+	"github.com/rancher/lasso/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +55,8 @@ type Controller struct {
 
 func (c *Controller) Register(ctx context.Context, factory controller.SharedControllerFactory) error {
 	c.ctx = ctx
+	c.handler.CtxID = metrics.ContextID(ctx)
+	c.handler.ControllerName = "dynamic.Controller"
 	c.cacheFactory = factory.SharedCacheFactory()
 	c.clientFactory = factory.SharedCacheFactory().SharedClientFactory()
 	return watchGVKS(ctx, c.discovery, factory, c.OnGVKs)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,7 +45,7 @@ var (
 			Name:      "total_handler_execution",
 			Help:      "Total count of handler executions",
 		},
-		[]string{controllerNameLabel, handlerNameLabel, hasErrorLabel},
+		[]string{contextLabel, controllerNameLabel, handlerNameLabel, hasErrorLabel},
 	)
 	TotalCachedObjects = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -62,13 +62,14 @@ var (
 		Subsystem: lassoSubsystem,
 		Name:      "reconcile_time_seconds",
 		Help:      "Histogram of the durations per reconciliation per controller",
-	}, []string{controllerNameLabel, handlerNameLabel, hasErrorLabel})
+	}, []string{contextLabel, controllerNameLabel, handlerNameLabel, hasErrorLabel})
 )
 
-func IncTotalHandlerExecutions(controllerName, handlerName string, hasError bool) {
+func IncTotalHandlerExecutions(ctxID, controllerName, handlerName string, hasError bool) {
 	if prometheusMetrics {
 		TotalControllerExecutions.With(
 			prometheus.Labels{
+				contextLabel:        ctxID,
 				controllerNameLabel: controllerName,
 				handlerNameLabel:    handlerName,
 				hasErrorLabel:       strconv.FormatBool(hasError),
@@ -105,10 +106,11 @@ func DelTotalCachedObjects(ctxID string, gvk schema.GroupVersionKind) {
 	}
 }
 
-func ReportReconcileTime(controllerName, handlerName string, hasError bool, observeTime float64) {
+func ReportReconcileTime(ctxID, controllerName, handlerName string, hasError bool, observeTime float64) {
 	if prometheusMetrics {
 		reconcileTime.With(
 			prometheus.Labels{
+				contextLabel:        ctxID,
 				controllerNameLabel: controllerName,
 				handlerNameLabel:    handlerName,
 				hasErrorLabel:       strconv.FormatBool(hasError),


### PR DESCRIPTION
Similarly to how it was added to `lasso_controller_total_cached_object` in #95, having this label will allow us to differentiate handler executions from different contexts while analyzing Prometheus metrics. It reuses the same instrumentation added for identifying the caches: https://github.com/rancher/rancher/pull/46784.

This change should be backwards compatible with existing dashboards, as they must be already using `sum` in some way.

Some example queries using a local build:
- Top 10 downstream handler executions:
![Screenshot 2025-04-02 at 11 12 54](https://github.com/user-attachments/assets/bda4f5ed-908f-4da6-8ef8-5de885f32be1)
- Comparing handlers from 2 downstream with 3 nodes vs. 1 node respectively:
![Screenshot 2025-04-02 at 10 27 43](https://github.com/user-attachments/assets/d2a3a380-d2c0-4890-9f12-c76fecef630a)
