### PR TITLE
[main] Allow for partial discovery list

### DIFF
--- a/pkg/dynamic/gvks.go
+++ b/pkg/dynamic/gvks.go
@@ -2,6 +2,7 @@ package dynamic
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -75,7 +76,11 @@ func (g *gvkWatcher) queueRefresh() {
 func (g *gvkWatcher) getGVKs() (result []schema.GroupVersionKind, _ error) {
 	_, resources, err := g.client.ServerGroupsAndResources()
 	if err != nil {
-		return nil, err
+		if gd, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
+			klog.Warning("Failed to read API for groups: ", gd.Groups)
+		} else {
+			return nil, fmt.Errorf("getGVKs: %w", err)
+		}
 	}
 	for _, resource := range resources {
 		for _, apiResource := range resource.APIResources {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/49299

Allow for partial GVK discovery and report errors via logs.

Note: The `APIService` startup is a bit bumpier. Since the discovery is allowed to succeed before the imperative-api is up an running, it can take more time before the `APIService` is able to discover the new resources and allow users to access those resource via ther kube apiserver.