### PR TITLE
Fix typo in test files

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -31,7 +31,7 @@ func TestController_multiple_finalizers_race(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	informer := NewMockSharedIndexInformer(ctrl)
 	informer.EXPECT().GetStore().Return(store).AnyTimes()
-	handler := &SharedHandler{controllerGVR: corev1.SchemeGroupVersion.WithResource("ConfigMap").String()}
+	handler := &SharedHandler{ControllerName: corev1.SchemeGroupVersion.WithResource("ConfigMap").String()}
 	c := &controller{
 		informer:  informer,
 		workqueue: queue,
@@ -108,7 +108,7 @@ func TestController_no_registered_handlers(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	informer := NewMockSharedIndexInformer(ctrl)
 	informer.EXPECT().GetStore().Return(store).AnyTimes()
-	handler := &SharedHandler{controllerGVR: corev1.SchemeGroupVersion.WithResource("ConfigMap").String()}
+	handler := &SharedHandler{ControllerName: corev1.SchemeGroupVersion.WithResource("ConfigMap").String()}
 	c := &controller{
 		informer:  informer,
 		workqueue: queue,


### PR DESCRIPTION
#156 introduced a typo in the tests files, due to a "last-minute" rename of the struct field.
For some reason the tests weren't executed as part of the PR CI so we never noticed