### PR TITLE
Watcher's ResultChan must be properly closed after Stop is called

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -339,14 +339,21 @@ func (c *Client) injectKind(w watch.Interface, err error) (watch.Interface, erro
 	}()
 
 	return &watcher{
-		Interface: w,
+		wrapped:   w,
 		eventChan: eventChan,
 	}, nil
 }
 
 type watcher struct {
-	watch.Interface
+	wrapped   watch.Interface
 	eventChan chan watch.Event
+}
+
+func (w *watcher) Stop() {
+	w.wrapped.Stop()
+	// Drain eventChan until the processing goroutine closes it, propagated from the original ResultChan
+	for range w.eventChan {
+	}
 }
 
 // ResultChan returns a receive only channel of watch events.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 )
@@ -532,6 +533,28 @@ func TestClient_Watch(t *testing.T) {
 			}
 			require.NoError(t, err)
 		})
+	}
+}
+
+func TestClient_Watch_Stop(t *testing.T) {
+	t.Parallel()
+	client := &Client{kind: "testkind"}
+	mockWatcher := watch.NewFake()
+	w, err := client.injectKind(mockWatcher, nil)
+	require.NoError(t, err)
+
+	resultChan := w.ResultChan()
+	mockWatcher.Add(nil)
+	w.Stop()
+
+	// Check that ResultChan is properly closed when Stop() is called
+	select {
+	case _, ok := <-resultChan:
+		if ok {
+			t.Error("expected result channel to be closed")
+		}
+	default:
+		t.Error("expected result channel to be closed")
 	}
 }
 


### PR DESCRIPTION
According to `apimachinery`'s [`Watch` interface](https://github.com/kubernetes/apimachinery/blob/master/pkg/watch/watch.go#L29-L51) (emphasis mine):

>  	// ResultChan returns a channel which will receive events from the event
>  	// producer. If an error occurs or Stop() is called, **the producer must
>  	// close this channel and release any resources used by the watch**.
>  	// Closing the result channel tells the consumer that no more events will be
>  	// sent.
>  	ResultChan() <-chan Event

However, our implementation of this interface does not satisfy that (I added a failing test that confirms it), forcing users to drain `ResultChan` after calling `Stop` in order to prevent memory leaks.
This change should not have any side effects on existing code with the mentioned workaround (with the unlikely exception of those events being actually used during draining, which we could argue should be discouraged. In other words, users must not use `ResultChan` once they call `Stop`).