### PR TITLE
Migrate renovate config to per-release-line presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,7 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranchPatterns": [
-    "main",
-    "release/v0.1"
+    "main"
   ],
   "prHourlyLimit": 2,
   "enabledManagers": [
@@ -18,45 +17,10 @@
       "extends": ["github>rancher/renovate-config:rancher-main#main"]
     },
     {
-      "description": "release/v0.1 predates every per-release-line preset and has no active consumer - every currently supported rancher branch pins lasso to a v0.2.x tag cut from main - so keep it fully disabled for k8s.io/sigs.k8s.io rather than adopting a ceiling that doesn't apply to it",
-      "enabled": false,
-      "matchBaseBranches": ["release/v0.1"],
-      "matchPackageNames": [
-        "/k8s.io/*/",
-        "/sigs.k8s.io/*/"
-      ]
-    },
-    {
       "enabled": false,
       "matchPackageNames": [
         "/github.com/prometheus/*/"
       ]
-    },
-    {
-      "description": "Disable major updates on release branches",
-      "matchUpdateTypes": ["major"],
-      "matchBaseBranches": ["/^release\\//"],
-      "enabled": false
-    },
-    {
-      "description": "Do not bump golang.org/x/tools minor/major on release branches - it tracks Go language releases and bumping it forces a go directive minor bump",
-      "matchPackageNames": ["golang.org/x/tools"],
-      "matchUpdateTypes": ["major", "minor"],
-      "matchBaseBranches": ["/^release\\//"],
-      "enabled": false
-    },
-    {
-      "description": "Do not bump the Go minor/major version on release branches",
-      "matchDepNames": ["go"],
-      "matchUpdateTypes": ["major", "minor"],
-      "matchBaseBranches": ["/^release\\//"],
-      "enabled": false
-    },
-    {
-      "description": "Do not update the rancher/renovate-config digest on release branches - only main's renovate.json is ever used, so keeping release branch copies in sync is unnecessary",
-      "matchDepNames": ["rancher/renovate-config"],
-      "matchBaseBranches": ["/^release\\//"],
-      "enabled": false
     },
     {
       "description": "Group all GitHub Actions updates into a single PR per branch",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,21 @@
   ],
   "packageRules": [
     {
+      "matchBaseBranches": ["main"],
+      "extends": ["github>rancher/renovate-config:rancher-main#main"]
+    },
+    {
+      "description": "release/v0.1 predates every per-release-line preset and has no active consumer - every currently supported rancher branch pins lasso to a v0.2.x tag cut from main - so keep it fully disabled for k8s.io/sigs.k8s.io rather than adopting a ceiling that doesn't apply to it",
       "enabled": false,
+      "matchBaseBranches": ["release/v0.1"],
       "matchPackageNames": [
         "/k8s.io/*/",
-        "/sigs.k8s.io/*/",
+        "/sigs.k8s.io/*/"
+      ]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": [
         "/github.com/prometheus/*/"
       ]
     },


### PR DESCRIPTION
Replaces the repo-local `k8s.io`/`sigs.k8s.io` disable rule with a per-branch `extends` of `rancher/renovate-config`'s per-release-line presets, per rancher/rancher#56562 (item 1 of the per-repo checklist, rancher/rancher#50186).

| lasso branch | preset | why |
|---|---|---|
| main | rancher-main | forward-looking, same convention as other repos |

Also takes release/v0.1 out of the renovate config entirely